### PR TITLE
when direction of render is changed, add the margin to the icons

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+v4.7.9
+==================
+* Fixed Dropdown icon spacing issue when the rendering direction is "rtl" Right-To-Left.
+
 v4.7.6
 ==================
 * fix event documentation

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "px-dropdown",
-  "version": "4.7.8",
+  "version": "4.7.9",
   "main": [
     "px-dropdown.html"
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "px-dropdown",
-    "version": "4.7.8",
+    "version": "4.7.9",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -28,11 +28,11 @@
             "integrity": "sha512-OlUjfM+Qv+XwcaucEiekBIhfAYe4q4ruvQZZcCkOtQZ27Hykxm1LLY2s0mE6LtP9XQt6x+TUvS70KW2e8Mz0ZA==",
             "dev": true,
             "requires": {
-                "@types/babel-generator": "6.25.1",
-                "@types/babel-template": "6.25.0",
-                "@types/babel-traverse": "6.25.3",
-                "@types/babel-types": "6.25.2",
-                "@types/babylon": "6.16.2"
+                "@types/babel-generator": "*",
+                "@types/babel-template": "*",
+                "@types/babel-traverse": "*",
+                "@types/babel-types": "*",
+                "@types/babylon": "*"
             }
         },
         "@types/babel-generator": {
@@ -41,7 +41,7 @@
             "integrity": "sha512-nKNz9Ch4WP2TFZjQROhxqqS2SCk0OoDzGazJI6S+2sGgW9P7N4o3vluZAXFuPEnRqtz2A0vrrkK3tjQktxIlRw==",
             "dev": true,
             "requires": {
-                "@types/babel-types": "6.25.2"
+                "@types/babel-types": "*"
             }
         },
         "@types/babel-template": {
@@ -50,8 +50,8 @@
             "integrity": "sha512-TtyfVlrprX92xSuKa8D//7vFz5kBJODBw5IQ1hQXehqO+me26vt1fyNxOZyXhUq2a7jRyT72V8p68IyH4NEZNA==",
             "dev": true,
             "requires": {
-                "@types/babel-types": "6.25.2",
-                "@types/babylon": "6.16.2"
+                "@types/babel-types": "*",
+                "@types/babylon": "*"
             }
         },
         "@types/babel-traverse": {
@@ -60,7 +60,7 @@
             "integrity": "sha512-4FaulWyA7nrXPkzoukL2VmSpxCnBZwc+MgwZqO30gtHCrtaUXnoxymdYfxzf3CZN80zjtrVzKfLlZ7FPYvrhQQ==",
             "dev": true,
             "requires": {
-                "@types/babel-types": "6.25.2"
+                "@types/babel-types": "*"
             }
         },
         "@types/babel-types": {
@@ -75,7 +75,7 @@
             "integrity": "sha512-+Jty46mPaWe1VAyZbfvgJM4BAdklLWxrT5tc/RjvCgLrtk6gzRY6AOnoWFv4p6hVxhJshDdr2hGVn56alBp97Q==",
             "dev": true,
             "requires": {
-                "@types/babel-types": "6.25.2"
+                "@types/babel-types": "*"
             }
         },
         "@types/bluebird": {
@@ -90,8 +90,8 @@
             "integrity": "sha512-BdN2PXxOFnTXFcyONPW6t0fHjz2fvRZHVMFpaS0wYr+Y8fWEaNOs4V8LEu/fpzQlMx+ahdndgTaGTwPC+J/EeA==",
             "dev": true,
             "requires": {
-                "@types/express": "4.0.39",
-                "@types/node": "8.0.53"
+                "@types/express": "*",
+                "@types/node": "*"
             }
         },
         "@types/chai": {
@@ -106,7 +106,7 @@
             "integrity": "sha512-Aof+FLfWzBPzDgJ2uuBuPNOBHVx9Siyw4vmOcsMgsuxX1nfUWSlzpq4pdvQiaBgGjGS7vP/Oft5dpJbX4krT1A==",
             "dev": true,
             "requires": {
-                "@types/chai": "4.0.6"
+                "@types/chai": "*"
             }
         },
         "@types/chalk": {
@@ -133,7 +133,7 @@
             "integrity": "sha1-ldxzOiM5qoRjgdfxN3eS0lU9wn0=",
             "dev": true,
             "requires": {
-                "@types/express": "4.0.39"
+                "@types/express": "*"
             }
         },
         "@types/content-type": {
@@ -154,7 +154,7 @@
             "integrity": "sha512-18mSs54BvzV8+TTQxt0ancig6tsuPZySnhp3cQkWFFDmDMavU4pmWwR+bHHqRBWODYqpzIzVkqKLuk/fP6yypQ==",
             "dev": true,
             "requires": {
-                "@types/glob": "5.0.33"
+                "@types/glob": "*"
             }
         },
         "@types/doctrine": {
@@ -175,7 +175,7 @@
             "integrity": "sha1-Zp9833KreX5hJfjQD+0z1M8wwiE=",
             "dev": true,
             "requires": {
-                "@types/estree": "0.0.37"
+                "@types/estree": "*"
             }
         },
         "@types/estree": {
@@ -190,9 +190,9 @@
             "integrity": "sha512-dBUam7jEjyuEofigUXCtublUHknRZvcRgITlGsTbFgPvnTwtQUt2NgLakbsf+PsGo/Nupqr3IXCYsOpBpofyrA==",
             "dev": true,
             "requires": {
-                "@types/body-parser": "1.16.8",
-                "@types/express-serve-static-core": "4.0.57",
-                "@types/serve-static": "1.13.1"
+                "@types/body-parser": "*",
+                "@types/express-serve-static-core": "*",
+                "@types/serve-static": "*"
             }
         },
         "@types/express-serve-static-core": {
@@ -201,7 +201,7 @@
             "integrity": "sha512-QLAHjdLwEICm3thVbXSKRoisjfgMVI4xJH/HU8F385BR2HI7PmM6ax4ELXf8Du6sLmSpySXMYaI+xc//oQ/IFw==",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.53"
+                "@types/node": "*"
             }
         },
         "@types/fast-levenshtein": {
@@ -216,7 +216,7 @@
             "integrity": "sha1-7AyAWX5e0VcoIgfnYspyVMrVdjI=",
             "dev": true,
             "requires": {
-                "@types/minimatch": "3.0.1"
+                "@types/minimatch": "*"
             }
         },
         "@types/form-data": {
@@ -225,7 +225,7 @@
             "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.53"
+                "@types/node": "*"
             }
         },
         "@types/freeport": {
@@ -241,8 +241,8 @@
             "integrity": "sha512-BcD4yyWz+qmCggaYMSFF0Xn7GkO6tgwm3Fh9Gxk/kQmEU3Z7flQTnVlMyKBUNvXXNTCCyjqK4XT4/2hLd1gQ2A==",
             "dev": true,
             "requires": {
-                "@types/minimatch": "3.0.1",
-                "@types/node": "8.0.53"
+                "@types/minimatch": "*",
+                "@types/node": "*"
             }
         },
         "@types/glob-stream": {
@@ -251,8 +251,8 @@
             "integrity": "sha512-UxdJkuoXh48URR4gJSAQAXSTeo98KTsEalJc+7wNmWrkK+8/z/V71tddUYzxtM/nlDJEKHW5Fbyh02KuHwlytg==",
             "dev": true,
             "requires": {
-                "@types/glob": "5.0.33",
-                "@types/node": "8.0.53"
+                "@types/glob": "*",
+                "@types/node": "*"
             }
         },
         "@types/gulp-if": {
@@ -261,8 +261,8 @@
             "integrity": "sha1-IaVkrxqryA3/LRlfpmzT+IZK7CE=",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.53",
-                "@types/vinyl": "2.0.1"
+                "@types/node": "*",
+                "@types/vinyl": "*"
             }
         },
         "@types/html-minifier": {
@@ -271,9 +271,9 @@
             "integrity": "sha1-OzgXwn3yOSL3taqH7/RbOrk0rsk=",
             "dev": true,
             "requires": {
-                "@types/clean-css": "3.4.30",
-                "@types/relateurl": "0.2.28",
-                "@types/uglify-js": "2.6.29"
+                "@types/clean-css": "*",
+                "@types/relateurl": "*",
+                "@types/uglify-js": "*"
             }
         },
         "@types/inquirer": {
@@ -282,8 +282,8 @@
             "integrity": "sha1-pKCOg3QcUAp8PI53dgFPf4plhw0=",
             "dev": true,
             "requires": {
-                "@types/rx": "4.1.1",
-                "@types/through": "0.0.29"
+                "@types/rx": "*",
+                "@types/through": "*"
             }
         },
         "@types/launchpad": {
@@ -299,7 +299,7 @@
             "integrity": "sha1-fKv6qrbGTVHjQQ2V4X3ZBh5BNTI=",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.53"
+                "@types/node": "*"
             }
         },
         "@types/mime": {
@@ -320,7 +320,7 @@
             "integrity": "sha1-pNgMCC/v5x5Ap8DwfR5lVbu8e1I=",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.53"
+                "@types/node": "*"
             }
         },
         "@types/node": {
@@ -335,7 +335,7 @@
             "integrity": "sha1-CX0NHJtXSVc6XZbfEyOHu20CEYo=",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.53"
+                "@types/node": "*"
             }
         },
         "@types/parse5": {
@@ -344,7 +344,7 @@
             "integrity": "sha1-44cKEOgnNacg9i1x3NGDunjvOp0=",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.53"
+                "@types/node": "*"
             }
         },
         "@types/pem": {
@@ -365,8 +365,8 @@
             "integrity": "sha512-cIvnyFRARxwE4OHpCyYue7H+SxaKFPpeleRCHJicft8QhyTNbVYsMwjvEzEPqG06D2LGHZ+sN5lXc8+bTu6D8A==",
             "dev": true,
             "requires": {
-                "@types/form-data": "2.2.1",
-                "@types/node": "8.0.53"
+                "@types/form-data": "*",
+                "@types/node": "*"
             }
         },
         "@types/resolve": {
@@ -375,7 +375,7 @@
             "integrity": "sha1-m1htZalH3qiMS8JNoLkF/pUgoNU=",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.53"
+                "@types/node": "*"
             }
         },
         "@types/rimraf": {
@@ -390,18 +390,18 @@
             "integrity": "sha1-WY/JSla67ZdfGUV04PVy/Y5iekg=",
             "dev": true,
             "requires": {
-                "@types/rx-core": "4.0.3",
-                "@types/rx-core-binding": "4.0.4",
-                "@types/rx-lite": "4.0.5",
-                "@types/rx-lite-aggregates": "4.0.3",
-                "@types/rx-lite-async": "4.0.2",
-                "@types/rx-lite-backpressure": "4.0.3",
-                "@types/rx-lite-coincidence": "4.0.3",
-                "@types/rx-lite-experimental": "4.0.1",
-                "@types/rx-lite-joinpatterns": "4.0.1",
-                "@types/rx-lite-testing": "4.0.1",
-                "@types/rx-lite-time": "4.0.3",
-                "@types/rx-lite-virtualtime": "4.0.3"
+                "@types/rx-core": "*",
+                "@types/rx-core-binding": "*",
+                "@types/rx-lite": "*",
+                "@types/rx-lite-aggregates": "*",
+                "@types/rx-lite-async": "*",
+                "@types/rx-lite-backpressure": "*",
+                "@types/rx-lite-coincidence": "*",
+                "@types/rx-lite-experimental": "*",
+                "@types/rx-lite-joinpatterns": "*",
+                "@types/rx-lite-testing": "*",
+                "@types/rx-lite-time": "*",
+                "@types/rx-lite-virtualtime": "*"
             }
         },
         "@types/rx-core": {
@@ -416,7 +416,7 @@
             "integrity": "sha512-5pkfxnC4w810LqBPUwP5bg7SFR/USwhMSaAeZQQbEHeBp57pjKXRlXmqpMrLJB4y1oglR/c2502853uN0I+DAQ==",
             "dev": true,
             "requires": {
-                "@types/rx-core": "4.0.3"
+                "@types/rx-core": "*"
             }
         },
         "@types/rx-lite": {
@@ -425,8 +425,8 @@
             "integrity": "sha512-KZk5XTR1dm/kNgBx8iVpjno6fRYtAUQWBOmj+O8j724+nk097sz4fOoHJNpCkOJUtHUurZlJC7QvSFCZHbkC+w==",
             "dev": true,
             "requires": {
-                "@types/rx-core": "4.0.3",
-                "@types/rx-core-binding": "4.0.4"
+                "@types/rx-core": "*",
+                "@types/rx-core-binding": "*"
             }
         },
         "@types/rx-lite-aggregates": {
@@ -435,7 +435,7 @@
             "integrity": "sha512-MAGDAHy8cRatm94FDduhJF+iNS5//jrZ/PIfm+QYw9OCeDgbymFHChM8YVIvN2zArwsRftKgE33QfRWvQk4DPg==",
             "dev": true,
             "requires": {
-                "@types/rx-lite": "4.0.5"
+                "@types/rx-lite": "*"
             }
         },
         "@types/rx-lite-async": {
@@ -444,7 +444,7 @@
             "integrity": "sha512-vTEv5o8l6702ZwfAM5aOeVDfUwBSDOs+ARoGmWAKQ6LOInQ8J4/zjM7ov12fuTpktUKdMQjkeCp07Vd73mPkxw==",
             "dev": true,
             "requires": {
-                "@types/rx-lite": "4.0.5"
+                "@types/rx-lite": "*"
             }
         },
         "@types/rx-lite-backpressure": {
@@ -453,7 +453,7 @@
             "integrity": "sha512-Y6aIeQCtNban5XSAF4B8dffhIKu6aAy/TXFlScHzSxh6ivfQBQw6UjxyEJxIOt3IT49YkS+siuayM2H/Q0cmgA==",
             "dev": true,
             "requires": {
-                "@types/rx-lite": "4.0.5"
+                "@types/rx-lite": "*"
             }
         },
         "@types/rx-lite-coincidence": {
@@ -462,7 +462,7 @@
             "integrity": "sha512-1VNJqzE9gALUyMGypDXZZXzR0Tt7LC9DdAZQ3Ou/Q0MubNU35agVUNXKGHKpNTba+fr8GdIdkC26bRDqtCQBeQ==",
             "dev": true,
             "requires": {
-                "@types/rx-lite": "4.0.5"
+                "@types/rx-lite": "*"
             }
         },
         "@types/rx-lite-experimental": {
@@ -471,7 +471,7 @@
             "integrity": "sha1-xTL1y98/LBXaFt7Ykw0bKYQCPL0=",
             "dev": true,
             "requires": {
-                "@types/rx-lite": "4.0.5"
+                "@types/rx-lite": "*"
             }
         },
         "@types/rx-lite-joinpatterns": {
@@ -480,7 +480,7 @@
             "integrity": "sha1-9w/jcFGKhDLykVjMkv+1a05K/D4=",
             "dev": true,
             "requires": {
-                "@types/rx-lite": "4.0.5"
+                "@types/rx-lite": "*"
             }
         },
         "@types/rx-lite-testing": {
@@ -489,7 +489,7 @@
             "integrity": "sha1-IbGdEfTf1v/vWp0WSOnIh5v+Iek=",
             "dev": true,
             "requires": {
-                "@types/rx-lite-virtualtime": "4.0.3"
+                "@types/rx-lite-virtualtime": "*"
             }
         },
         "@types/rx-lite-time": {
@@ -498,7 +498,7 @@
             "integrity": "sha512-ukO5sPKDRwCGWRZRqPlaAU0SKVxmWwSjiOrLhoQDoWxZWg6vyB9XLEZViKOzIO6LnTIQBlk4UylYV0rnhJLxQw==",
             "dev": true,
             "requires": {
-                "@types/rx-lite": "4.0.5"
+                "@types/rx-lite": "*"
             }
         },
         "@types/rx-lite-virtualtime": {
@@ -507,7 +507,7 @@
             "integrity": "sha512-3uC6sGmjpOKatZSVHI2xB1+dedgml669ZRvqxy+WqmGJDVusOdyxcKfyzjW0P3/GrCiN4nmRkLVMhPwHCc5QLg==",
             "dev": true,
             "requires": {
-                "@types/rx-lite": "4.0.5"
+                "@types/rx-lite": "*"
             }
         },
         "@types/semver": {
@@ -522,8 +522,8 @@
             "integrity": "sha512-jDMH+3BQPtvqZVIcsH700Dfi8Q3MIcEx16g/VdxjoqiGR/NntekB10xdBpirMKnPe9z2C5cBmL0vte0YttOr3Q==",
             "dev": true,
             "requires": {
-                "@types/express-serve-static-core": "4.0.57",
-                "@types/mime": "0.0.29"
+                "@types/express-serve-static-core": "*",
+                "@types/mime": "*"
             }
         },
         "@types/source-map": {
@@ -538,7 +538,7 @@
             "integrity": "sha512-N9LBlbVRRYq6HgYpPkqQc3a9HJ/iEtVZToW6xlTtJiMhmRJ7jJdV7TaZQJw/Ve/1ePUsQiCTDc4JMuzzag94GA==",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.53"
+                "@types/node": "*"
             }
         },
         "@types/temp": {
@@ -547,7 +547,7 @@
             "integrity": "sha512-zlQRhRYRTuO1lNF0WIYshou/BaVPslf6Rg6jm6sykKn9G/8gOKtlAXtWAZzyQl762XBtpdhsoP5WuN902OQ6RQ==",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.53"
+                "@types/node": "*"
             }
         },
         "@types/through": {
@@ -556,7 +556,7 @@
             "integrity": "sha512-9a7C5VHh+1BKblaYiq+7Tfc+EOmjMdZaD1MYtkQjSoxgB69tBjW98ry6SKsi4zEIWztLOMRuL87A3bdT/Fc/4w==",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.53"
+                "@types/node": "*"
             }
         },
         "@types/ua-parser-js": {
@@ -571,7 +571,7 @@
             "integrity": "sha512-BdFLCZW0GTl31AbqXSak8ss/MqEZ3DN2MH9rkAyGoTuzK7ifGUlX+u0nfbWeTsa7IPcZhtn8BlpYBXSV+vqGhQ==",
             "dev": true,
             "requires": {
-                "@types/source-map": "0.5.2"
+                "@types/source-map": "*"
             }
         },
         "@types/update-notifier": {
@@ -586,7 +586,7 @@
             "integrity": "sha512-Joudabfn2ZofU2usW04y8OLmN75u7ZQkW0MCT3AnoBf5oUBp5iQ3Pgfz9+y1RdWkzhCPZo9/wBJ7FMWW2JrY0g==",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.53"
+                "@types/node": "*"
             }
         },
         "@types/vinyl-fs": {
@@ -595,9 +595,9 @@
             "integrity": "sha1-RmMBe8gCxlcOrk80Cf1cq/l8v94=",
             "dev": true,
             "requires": {
-                "@types/glob-stream": "3.1.31",
-                "@types/node": "8.0.53",
-                "@types/vinyl": "2.0.1"
+                "@types/glob-stream": "*",
+                "@types/node": "*",
+                "@types/vinyl": "*"
             }
         },
         "@types/which": {
@@ -613,7 +613,7 @@
             "integrity": "sha512-jNhbkxPtt9xbzvihfA0OavjJbpCIyTDSmwE03BVXgCKcz9lwNsq4cg2wsNkY4Av5eH35ttBArhYtVJa6CIrg2A==",
             "dev": true,
             "requires": {
-                "@types/node": "8.0.53"
+                "@types/node": "*"
             }
         },
         "@types/yeoman-generator": {
@@ -622,7 +622,7 @@
             "integrity": "sha512-iMm6ZU90vgupfqIDMQSSKh7VfM3susAoXx8Zv79FGnpiExtUTq8HeAg0AlrwqeP00VpPO/x/ytNejmmyuNoT/A==",
             "dev": true,
             "requires": {
-                "@types/inquirer": "0.0.32"
+                "@types/inquirer": "*"
             }
         },
         "@webcomponents/webcomponentsjs": {
@@ -643,7 +643,7 @@
             "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
             "dev": true,
             "requires": {
-                "mime-types": "2.1.17",
+                "mime-types": "~2.1.16",
                 "negotiator": "0.6.1"
             }
         },
@@ -665,7 +665,7 @@
             "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
             "dev": true,
             "requires": {
-                "acorn": "3.3.0"
+                "acorn": "^3.0.4"
             },
             "dependencies": {
                 "acorn": {
@@ -695,8 +695,8 @@
             "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
             "dev": true,
             "requires": {
-                "extend": "3.0.1",
-                "semver": "5.0.3"
+                "extend": "~3.0.0",
+                "semver": "~5.0.1"
             },
             "dependencies": {
                 "semver": {
@@ -713,8 +713,8 @@
             "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
             "dev": true,
             "requires": {
-                "co": "4.6.0",
-                "json-stable-stringify": "1.0.1"
+                "co": "^4.6.0",
+                "json-stable-stringify": "^1.0.1"
             }
         },
         "amdefine": {
@@ -729,7 +729,7 @@
             "integrity": "sha1-LwwWWIKXOa3V67FeawxuNCPwFro=",
             "dev": true,
             "requires": {
-                "string-width": "1.0.2"
+                "string-width": "^1.0.1"
             }
         },
         "ansi-colors": {
@@ -738,7 +738,7 @@
             "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
             "dev": true,
             "requires": {
-                "ansi-wrap": "0.1.0"
+                "ansi-wrap": "^0.1.0"
             }
         },
         "ansi-cyan": {
@@ -756,7 +756,7 @@
             "integrity": "sha1-HBg5S2r5t2/5pjUJ+kl2af0s5T4=",
             "dev": true,
             "requires": {
-                "array-back": "1.0.4"
+                "array-back": "^1.0.3"
             }
         },
         "ansi-escapes": {
@@ -804,8 +804,8 @@
             "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
             "dev": true,
             "requires": {
-                "micromatch": "2.3.11",
-                "normalize-path": "2.1.1"
+                "micromatch": "^2.1.5",
+                "normalize-path": "^2.0.0"
             }
         },
         "append-field": {
@@ -826,15 +826,15 @@
             "integrity": "sha1-TyGU1tj5nfP1MeaIHxTxXVX6ryI=",
             "dev": true,
             "requires": {
-                "archiver-utils": "1.3.0",
-                "async": "2.6.0",
-                "buffer-crc32": "0.2.13",
-                "glob": "7.1.2",
-                "lodash": "4.17.4",
-                "readable-stream": "2.3.3",
-                "tar-stream": "1.5.5",
-                "walkdir": "0.0.11",
-                "zip-stream": "1.2.0"
+                "archiver-utils": "^1.3.0",
+                "async": "^2.0.0",
+                "buffer-crc32": "^0.2.1",
+                "glob": "^7.0.0",
+                "lodash": "^4.8.0",
+                "readable-stream": "^2.0.0",
+                "tar-stream": "^1.5.0",
+                "walkdir": "^0.0.11",
+                "zip-stream": "^1.1.0"
             },
             "dependencies": {
                 "async": {
@@ -843,7 +843,7 @@
                     "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
                     "dev": true,
                     "requires": {
-                        "lodash": "4.17.4"
+                        "lodash": "^4.14.0"
                     }
                 },
                 "glob": {
@@ -852,12 +852,12 @@
                     "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.3.3",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "lodash": {
@@ -874,12 +874,12 @@
             "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
             "dev": true,
             "requires": {
-                "glob": "7.1.2",
-                "graceful-fs": "4.1.11",
-                "lazystream": "1.0.0",
-                "lodash": "4.17.4",
-                "normalize-path": "2.1.1",
-                "readable-stream": "2.3.3"
+                "glob": "^7.0.0",
+                "graceful-fs": "^4.1.0",
+                "lazystream": "^1.0.0",
+                "lodash": "^4.8.0",
+                "normalize-path": "^2.0.0",
+                "readable-stream": "^2.0.0"
             },
             "dependencies": {
                 "glob": {
@@ -888,12 +888,12 @@
                     "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.3.3",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "lodash": {
@@ -916,8 +916,8 @@
             "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
             "dev": true,
             "requires": {
-                "delegates": "1.0.0",
-                "readable-stream": "2.3.3"
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.6"
             }
         },
         "argparse": {
@@ -926,7 +926,7 @@
             "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
             "dev": true,
             "requires": {
-                "sprintf-js": "1.0.3"
+                "sprintf-js": "~1.0.2"
             }
         },
         "arr-diff": {
@@ -935,7 +935,7 @@
             "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
             "dev": true,
             "requires": {
-                "arr-flatten": "1.1.0"
+                "arr-flatten": "^1.0.1"
             }
         },
         "arr-flatten": {
@@ -956,7 +956,7 @@
             "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
             "dev": true,
             "requires": {
-                "typical": "2.6.1"
+                "typical": "^2.6.0"
             }
         },
         "array-differ": {
@@ -984,9 +984,9 @@
             "dev": true
         },
         "array-slice": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.0.0.tgz",
-            "integrity": "sha1-5zA08A3MH0CHYAj9IP6ud71LfC8=",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
+            "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w==",
             "dev": true
         },
         "array-union": {
@@ -995,7 +995,7 @@
             "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
             "dev": true,
             "requires": {
-                "array-uniq": "1.0.3"
+                "array-uniq": "^1.0.1"
             }
         },
         "array-uniq": {
@@ -1088,18 +1088,24 @@
             "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
             "dev": true
         },
+        "atob": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+            "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+            "dev": true
+        },
         "autoprefixer": {
             "version": "6.7.7",
             "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
             "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
             "dev": true,
             "requires": {
-                "browserslist": "1.7.7",
-                "caniuse-db": "1.0.30000772",
-                "normalize-range": "0.1.2",
-                "num2fraction": "1.2.2",
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
+                "browserslist": "^1.7.6",
+                "caniuse-db": "^1.0.30000634",
+                "normalize-range": "^0.1.2",
+                "num2fraction": "^1.2.2",
+                "postcss": "^5.2.16",
+                "postcss-value-parser": "^3.2.3"
             }
         },
         "aws-sign2": {
@@ -1120,9 +1126,9 @@
             "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "esutils": "2.0.2",
-                "js-tokens": "3.0.2"
+                "chalk": "^1.1.3",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.2"
             }
         },
         "babel-core": {
@@ -1131,25 +1137,25 @@
             "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
             "dev": true,
             "requires": {
-                "babel-code-frame": "6.26.0",
-                "babel-generator": "6.26.0",
-                "babel-helpers": "6.24.1",
-                "babel-messages": "6.23.0",
-                "babel-register": "6.26.0",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0",
-                "babylon": "6.18.0",
-                "convert-source-map": "1.5.1",
-                "debug": "2.6.9",
-                "json5": "0.5.1",
-                "lodash": "4.17.4",
-                "minimatch": "3.0.4",
-                "path-is-absolute": "1.0.1",
-                "private": "0.1.8",
-                "slash": "1.0.0",
-                "source-map": "0.5.7"
+                "babel-code-frame": "^6.26.0",
+                "babel-generator": "^6.26.0",
+                "babel-helpers": "^6.24.1",
+                "babel-messages": "^6.23.0",
+                "babel-register": "^6.26.0",
+                "babel-runtime": "^6.26.0",
+                "babel-template": "^6.26.0",
+                "babel-traverse": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "babylon": "^6.18.0",
+                "convert-source-map": "^1.5.0",
+                "debug": "^2.6.8",
+                "json5": "^0.5.1",
+                "lodash": "^4.17.4",
+                "minimatch": "^3.0.4",
+                "path-is-absolute": "^1.0.1",
+                "private": "^0.1.7",
+                "slash": "^1.0.0",
+                "source-map": "^0.5.6"
             },
             "dependencies": {
                 "debug": {
@@ -1181,14 +1187,14 @@
             "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
             "dev": true,
             "requires": {
-                "babel-messages": "6.23.0",
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0",
-                "detect-indent": "4.0.0",
-                "jsesc": "1.3.0",
-                "lodash": "4.17.4",
-                "source-map": "0.5.7",
-                "trim-right": "1.0.1"
+                "babel-messages": "^6.23.0",
+                "babel-runtime": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "detect-indent": "^4.0.0",
+                "jsesc": "^1.3.0",
+                "lodash": "^4.17.4",
+                "source-map": "^0.5.6",
+                "trim-right": "^1.0.1"
             },
             "dependencies": {
                 "lodash": {
@@ -1205,10 +1211,10 @@
             "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
             "dev": true,
             "requires": {
-                "babel-helper-hoist-variables": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-helper-hoist-variables": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-helper-define-map": {
@@ -1217,10 +1223,10 @@
             "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
             "dev": true,
             "requires": {
-                "babel-helper-function-name": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0",
-                "lodash": "4.17.4"
+                "babel-helper-function-name": "^6.24.1",
+                "babel-runtime": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "lodash": "^4.17.4"
             },
             "dependencies": {
                 "lodash": {
@@ -1249,11 +1255,11 @@
             "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
             "dev": true,
             "requires": {
-                "babel-helper-get-function-arity": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-helper-get-function-arity": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-helper-get-function-arity": {
@@ -1262,8 +1268,8 @@
             "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-helper-hoist-variables": {
@@ -1272,8 +1278,8 @@
             "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-helper-is-nodes-equiv": {
@@ -1300,8 +1306,8 @@
             "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-helper-regex": {
@@ -1310,9 +1316,9 @@
             "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0",
-                "lodash": "4.17.4"
+                "babel-runtime": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "lodash": "^4.17.4"
             },
             "dependencies": {
                 "lodash": {
@@ -1335,12 +1341,12 @@
             "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
             "dev": true,
             "requires": {
-                "babel-helper-optimise-call-expression": "6.24.1",
-                "babel-messages": "6.23.0",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-helper-optimise-call-expression": "^6.24.1",
+                "babel-messages": "^6.23.0",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-helper-to-multiple-sequence-expressions": {
@@ -1355,8 +1361,8 @@
             "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0"
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1"
             }
         },
         "babel-messages": {
@@ -1365,7 +1371,7 @@
             "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-check-es2015-constants": {
@@ -1374,7 +1380,7 @@
             "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-external-helpers": {
@@ -1383,7 +1389,7 @@
             "integrity": "sha1-IoX0iwK9Xe3oUXXK+MYuhq3M76E=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-minify-builtins": {
@@ -1392,7 +1398,7 @@
             "integrity": "sha512-4i+8ntaS8gwVUcOz5y+zE+55OVOl2nTbmHV51D4wAIiKcRI8U5K//ip1GHfhsgk/NJrrHK7h97Oy5jpqt0Iixg==",
             "dev": true,
             "requires": {
-                "babel-helper-evaluate-path": "0.2.0"
+                "babel-helper-evaluate-path": "^0.2.0"
             }
         },
         "babel-plugin-minify-constant-folding": {
@@ -1401,7 +1407,7 @@
             "integrity": "sha512-B3ffQBEUQ8ydlIkYv2MkZtTCbV7FAkWAV7NkyhcXlGpD10PaCxNGQ/B9oguXGowR1m16Q5nGhvNn8Pkn1MO6Hw==",
             "dev": true,
             "requires": {
-                "babel-helper-evaluate-path": "0.2.0"
+                "babel-helper-evaluate-path": "^0.2.0"
             }
         },
         "babel-plugin-minify-dead-code-elimination": {
@@ -1410,10 +1416,10 @@
             "integrity": "sha512-zE7y3pRyzA4zK5nBou0kTcwUTSQ/AiFrynt1cIEYN7vcO2gS9ZFZoI0aO9JYLUdct5fsC1vfB35408yrzTyVfg==",
             "dev": true,
             "requires": {
-                "babel-helper-evaluate-path": "0.2.0",
-                "babel-helper-mark-eval-scopes": "0.2.0",
-                "babel-helper-remove-or-void": "0.2.0",
-                "lodash.some": "4.6.0"
+                "babel-helper-evaluate-path": "^0.2.0",
+                "babel-helper-mark-eval-scopes": "^0.2.0",
+                "babel-helper-remove-or-void": "^0.2.0",
+                "lodash.some": "^4.6.0"
             }
         },
         "babel-plugin-minify-flip-comparisons": {
@@ -1422,7 +1428,7 @@
             "integrity": "sha512-QOqXSEmD/LhT3LpM1WCyzAGcQZYYKJF7oOHvS6QbpomHenydrV53DMdPX2mK01icBExKZcJAHF209wvDBa+CSg==",
             "dev": true,
             "requires": {
-                "babel-helper-is-void-0": "0.2.0"
+                "babel-helper-is-void-0": "^0.2.0"
             }
         },
         "babel-plugin-minify-guarded-expressions": {
@@ -1431,7 +1437,7 @@
             "integrity": "sha512-5+NSPdRQ9mnrHaA+zFj+D5OzmSiv90EX5zGH6cWQgR/OUqmCHSDqgTRPFvOctgpo8MJyO7Rt7ajs2UfLnlAwYg==",
             "dev": true,
             "requires": {
-                "babel-helper-flip-expressions": "0.2.0"
+                "babel-helper-flip-expressions": "^0.2.0"
             }
         },
         "babel-plugin-minify-infinity": {
@@ -1446,7 +1452,7 @@
             "integrity": "sha512-Gixuak1/CO7VCdjn15/8Bxe/QsAtDG4zPbnsNoe1mIJGCIH/kcmSjFhMlGJtXDQZd6EKzeMfA5WmX9+jvGRefw==",
             "dev": true,
             "requires": {
-                "babel-helper-mark-eval-scopes": "0.2.0"
+                "babel-helper-mark-eval-scopes": "^0.2.0"
             }
         },
         "babel-plugin-minify-numeric-literals": {
@@ -1467,9 +1473,9 @@
             "integrity": "sha512-Mj3Mwy2zVosMfXDWXZrQH5/uMAyfJdmDQ1NVqit+ArbHC3LlXVzptuyC1JxTyai/wgFvjLaichm/7vSUshkWqw==",
             "dev": true,
             "requires": {
-                "babel-helper-flip-expressions": "0.2.0",
-                "babel-helper-is-nodes-equiv": "0.0.1",
-                "babel-helper-to-multiple-sequence-expressions": "0.2.0"
+                "babel-helper-flip-expressions": "^0.2.0",
+                "babel-helper-is-nodes-equiv": "^0.0.1",
+                "babel-helper-to-multiple-sequence-expressions": "^0.2.0"
             }
         },
         "babel-plugin-minify-type-constructors": {
@@ -1478,7 +1484,7 @@
             "integrity": "sha512-NiOvvA9Pq6bki6nP4BayXwT5GZadw7DJFDDzHmkpnOQpENWe8RtHtKZM44MG1R6EQ5XxgbLdsdhswIzTkFlO5g==",
             "dev": true,
             "requires": {
-                "babel-helper-is-void-0": "0.2.0"
+                "babel-helper-is-void-0": "^0.2.0"
             }
         },
         "babel-plugin-transform-es2015-arrow-functions": {
@@ -1487,7 +1493,7 @@
             "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-block-scoped-functions": {
@@ -1496,7 +1502,7 @@
             "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-block-scoping": {
@@ -1505,11 +1511,11 @@
             "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0",
-                "lodash": "4.17.4"
+                "babel-runtime": "^6.26.0",
+                "babel-template": "^6.26.0",
+                "babel-traverse": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "lodash": "^4.17.4"
             },
             "dependencies": {
                 "lodash": {
@@ -1526,15 +1532,15 @@
             "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
             "dev": true,
             "requires": {
-                "babel-helper-define-map": "6.26.0",
-                "babel-helper-function-name": "6.24.1",
-                "babel-helper-optimise-call-expression": "6.24.1",
-                "babel-helper-replace-supers": "6.24.1",
-                "babel-messages": "6.23.0",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-helper-define-map": "^6.24.1",
+                "babel-helper-function-name": "^6.24.1",
+                "babel-helper-optimise-call-expression": "^6.24.1",
+                "babel-helper-replace-supers": "^6.24.1",
+                "babel-messages": "^6.23.0",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-plugin-transform-es2015-computed-properties": {
@@ -1543,8 +1549,8 @@
             "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0"
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1"
             }
         },
         "babel-plugin-transform-es2015-destructuring": {
@@ -1553,7 +1559,7 @@
             "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-duplicate-keys": {
@@ -1562,8 +1568,8 @@
             "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-plugin-transform-es2015-for-of": {
@@ -1572,7 +1578,7 @@
             "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-function-name": {
@@ -1581,9 +1587,9 @@
             "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
             "dev": true,
             "requires": {
-                "babel-helper-function-name": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-helper-function-name": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-plugin-transform-es2015-literals": {
@@ -1592,7 +1598,7 @@
             "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-modules-amd": {
@@ -1601,9 +1607,9 @@
             "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
             "dev": true,
             "requires": {
-                "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0"
+                "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1"
             }
         },
         "babel-plugin-transform-es2015-modules-commonjs": {
@@ -1612,10 +1618,10 @@
             "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
             "dev": true,
             "requires": {
-                "babel-plugin-transform-strict-mode": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-plugin-transform-strict-mode": "^6.24.1",
+                "babel-runtime": "^6.26.0",
+                "babel-template": "^6.26.0",
+                "babel-types": "^6.26.0"
             }
         },
         "babel-plugin-transform-es2015-modules-systemjs": {
@@ -1624,9 +1630,9 @@
             "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
             "dev": true,
             "requires": {
-                "babel-helper-hoist-variables": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0"
+                "babel-helper-hoist-variables": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1"
             }
         },
         "babel-plugin-transform-es2015-modules-umd": {
@@ -1635,9 +1641,9 @@
             "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
             "dev": true,
             "requires": {
-                "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0"
+                "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1"
             }
         },
         "babel-plugin-transform-es2015-object-super": {
@@ -1646,8 +1652,8 @@
             "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
             "dev": true,
             "requires": {
-                "babel-helper-replace-supers": "6.24.1",
-                "babel-runtime": "6.26.0"
+                "babel-helper-replace-supers": "^6.24.1",
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-parameters": {
@@ -1656,12 +1662,12 @@
             "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
             "dev": true,
             "requires": {
-                "babel-helper-call-delegate": "6.24.1",
-                "babel-helper-get-function-arity": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-helper-call-delegate": "^6.24.1",
+                "babel-helper-get-function-arity": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-plugin-transform-es2015-shorthand-properties": {
@@ -1670,8 +1676,8 @@
             "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-plugin-transform-es2015-spread": {
@@ -1680,7 +1686,7 @@
             "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-sticky-regex": {
@@ -1689,9 +1695,9 @@
             "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
             "dev": true,
             "requires": {
-                "babel-helper-regex": "6.26.0",
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-helper-regex": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-plugin-transform-es2015-template-literals": {
@@ -1700,7 +1706,7 @@
             "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-typeof-symbol": {
@@ -1709,7 +1715,7 @@
             "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-unicode-regex": {
@@ -1718,9 +1724,9 @@
             "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
             "dev": true,
             "requires": {
-                "babel-helper-regex": "6.26.0",
-                "babel-runtime": "6.26.0",
-                "regexpu-core": "2.0.0"
+                "babel-helper-regex": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "regexpu-core": "^2.0.0"
             }
         },
         "babel-plugin-transform-inline-consecutive-adds": {
@@ -1753,7 +1759,7 @@
             "integrity": "sha512-MmiQsQ5AcIaRZMJD0zY5C4H3xuHm06/nWgtOsz7AXV44VEIXIlPiJ39IFYJ4Qx67/fEm8zJAedzR8t+B7d10Bg==",
             "dev": true,
             "requires": {
-                "esutils": "2.0.2"
+                "esutils": "^2.0.2"
             }
         },
         "babel-plugin-transform-regenerator": {
@@ -1762,7 +1768,7 @@
             "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
             "dev": true,
             "requires": {
-                "regenerator-transform": "0.10.1"
+                "regenerator-transform": "^0.10.0"
             }
         },
         "babel-plugin-transform-regexp-constructors": {
@@ -1789,7 +1795,7 @@
             "integrity": "sha512-O8v57tPMHkp89kA4ZfQEYds/pzgvz/QYerBJjIuL5/Jc7RnvMVRA5gJY9zFKP7WayW8WOSBV4vh8Y8FJRio+ow==",
             "dev": true,
             "requires": {
-                "babel-helper-evaluate-path": "0.2.0"
+                "babel-helper-evaluate-path": "^0.2.0"
             }
         },
         "babel-plugin-transform-simplify-comparison-operators": {
@@ -1804,8 +1810,8 @@
             "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-plugin-transform-undefined-to-void": {
@@ -1820,30 +1826,30 @@
             "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
             "dev": true,
             "requires": {
-                "babel-plugin-check-es2015-constants": "6.22.0",
-                "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-                "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-                "babel-plugin-transform-es2015-block-scoping": "6.26.0",
-                "babel-plugin-transform-es2015-classes": "6.24.1",
-                "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-                "babel-plugin-transform-es2015-destructuring": "6.23.0",
-                "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-                "babel-plugin-transform-es2015-for-of": "6.23.0",
-                "babel-plugin-transform-es2015-function-name": "6.24.1",
-                "babel-plugin-transform-es2015-literals": "6.22.0",
-                "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-                "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-                "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-                "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-                "babel-plugin-transform-es2015-object-super": "6.24.1",
-                "babel-plugin-transform-es2015-parameters": "6.24.1",
-                "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-                "babel-plugin-transform-es2015-spread": "6.22.0",
-                "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-                "babel-plugin-transform-es2015-template-literals": "6.22.0",
-                "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-                "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-                "babel-plugin-transform-regenerator": "6.26.0"
+                "babel-plugin-check-es2015-constants": "^6.22.0",
+                "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+                "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+                "babel-plugin-transform-es2015-block-scoping": "^6.24.1",
+                "babel-plugin-transform-es2015-classes": "^6.24.1",
+                "babel-plugin-transform-es2015-computed-properties": "^6.24.1",
+                "babel-plugin-transform-es2015-destructuring": "^6.22.0",
+                "babel-plugin-transform-es2015-duplicate-keys": "^6.24.1",
+                "babel-plugin-transform-es2015-for-of": "^6.22.0",
+                "babel-plugin-transform-es2015-function-name": "^6.24.1",
+                "babel-plugin-transform-es2015-literals": "^6.22.0",
+                "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+                "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+                "babel-plugin-transform-es2015-modules-systemjs": "^6.24.1",
+                "babel-plugin-transform-es2015-modules-umd": "^6.24.1",
+                "babel-plugin-transform-es2015-object-super": "^6.24.1",
+                "babel-plugin-transform-es2015-parameters": "^6.24.1",
+                "babel-plugin-transform-es2015-shorthand-properties": "^6.24.1",
+                "babel-plugin-transform-es2015-spread": "^6.22.0",
+                "babel-plugin-transform-es2015-sticky-regex": "^6.24.1",
+                "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+                "babel-plugin-transform-es2015-typeof-symbol": "^6.22.0",
+                "babel-plugin-transform-es2015-unicode-regex": "^6.24.1",
+                "babel-plugin-transform-regenerator": "^6.24.1"
             }
         },
         "babel-preset-minify": {
@@ -1852,29 +1858,29 @@
             "integrity": "sha512-mR8Q44RmMzm18bM2Lqd9uiPopzk5GDCtVuquNbLFmX6lOKnqWoenaNBxnWW0UhBFC75lEHTIgNGCbnsRI0pJVw==",
             "dev": true,
             "requires": {
-                "babel-plugin-minify-builtins": "0.2.0",
-                "babel-plugin-minify-constant-folding": "0.2.0",
-                "babel-plugin-minify-dead-code-elimination": "0.2.0",
-                "babel-plugin-minify-flip-comparisons": "0.2.0",
-                "babel-plugin-minify-guarded-expressions": "0.2.0",
-                "babel-plugin-minify-infinity": "0.2.0",
-                "babel-plugin-minify-mangle-names": "0.2.0",
-                "babel-plugin-minify-numeric-literals": "0.2.0",
-                "babel-plugin-minify-replace": "0.2.0",
-                "babel-plugin-minify-simplify": "0.2.0",
-                "babel-plugin-minify-type-constructors": "0.2.0",
-                "babel-plugin-transform-inline-consecutive-adds": "0.2.0",
-                "babel-plugin-transform-member-expression-literals": "6.8.5",
-                "babel-plugin-transform-merge-sibling-variables": "6.8.6",
-                "babel-plugin-transform-minify-booleans": "6.8.3",
-                "babel-plugin-transform-property-literals": "6.8.5",
-                "babel-plugin-transform-regexp-constructors": "0.2.0",
-                "babel-plugin-transform-remove-console": "6.8.5",
-                "babel-plugin-transform-remove-debugger": "6.8.5",
-                "babel-plugin-transform-remove-undefined": "0.2.0",
-                "babel-plugin-transform-simplify-comparison-operators": "6.8.5",
-                "babel-plugin-transform-undefined-to-void": "6.8.3",
-                "lodash.isplainobject": "4.0.6"
+                "babel-plugin-minify-builtins": "^0.2.0",
+                "babel-plugin-minify-constant-folding": "^0.2.0",
+                "babel-plugin-minify-dead-code-elimination": "^0.2.0",
+                "babel-plugin-minify-flip-comparisons": "^0.2.0",
+                "babel-plugin-minify-guarded-expressions": "^0.2.0",
+                "babel-plugin-minify-infinity": "^0.2.0",
+                "babel-plugin-minify-mangle-names": "^0.2.0",
+                "babel-plugin-minify-numeric-literals": "^0.2.0",
+                "babel-plugin-minify-replace": "^0.2.0",
+                "babel-plugin-minify-simplify": "^0.2.0",
+                "babel-plugin-minify-type-constructors": "^0.2.0",
+                "babel-plugin-transform-inline-consecutive-adds": "^0.2.0",
+                "babel-plugin-transform-member-expression-literals": "^6.8.5",
+                "babel-plugin-transform-merge-sibling-variables": "^6.8.6",
+                "babel-plugin-transform-minify-booleans": "^6.8.3",
+                "babel-plugin-transform-property-literals": "^6.8.5",
+                "babel-plugin-transform-regexp-constructors": "^0.2.0",
+                "babel-plugin-transform-remove-console": "^6.8.5",
+                "babel-plugin-transform-remove-debugger": "^6.8.5",
+                "babel-plugin-transform-remove-undefined": "^0.2.0",
+                "babel-plugin-transform-simplify-comparison-operators": "^6.8.5",
+                "babel-plugin-transform-undefined-to-void": "^6.8.3",
+                "lodash.isplainobject": "^4.0.6"
             }
         },
         "babel-register": {
@@ -1883,13 +1889,13 @@
             "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
             "dev": true,
             "requires": {
-                "babel-core": "6.26.0",
-                "babel-runtime": "6.26.0",
-                "core-js": "2.5.1",
-                "home-or-tmp": "2.0.0",
-                "lodash": "4.17.4",
-                "mkdirp": "0.5.1",
-                "source-map-support": "0.4.18"
+                "babel-core": "^6.26.0",
+                "babel-runtime": "^6.26.0",
+                "core-js": "^2.5.0",
+                "home-or-tmp": "^2.0.0",
+                "lodash": "^4.17.4",
+                "mkdirp": "^0.5.1",
+                "source-map-support": "^0.4.15"
             },
             "dependencies": {
                 "lodash": {
@@ -1921,8 +1927,8 @@
             "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
             "dev": true,
             "requires": {
-                "core-js": "2.5.1",
-                "regenerator-runtime": "0.11.0"
+                "core-js": "^2.4.0",
+                "regenerator-runtime": "^0.11.0"
             }
         },
         "babel-template": {
@@ -1931,11 +1937,11 @@
             "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0",
-                "babylon": "6.18.0",
-                "lodash": "4.17.4"
+                "babel-runtime": "^6.26.0",
+                "babel-traverse": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "babylon": "^6.18.0",
+                "lodash": "^4.17.4"
             },
             "dependencies": {
                 "lodash": {
@@ -1952,15 +1958,15 @@
             "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
             "dev": true,
             "requires": {
-                "babel-code-frame": "6.26.0",
-                "babel-messages": "6.23.0",
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0",
-                "babylon": "6.18.0",
-                "debug": "2.6.9",
-                "globals": "9.18.0",
-                "invariant": "2.2.2",
-                "lodash": "4.17.4"
+                "babel-code-frame": "^6.26.0",
+                "babel-messages": "^6.23.0",
+                "babel-runtime": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "babylon": "^6.18.0",
+                "debug": "^2.6.8",
+                "globals": "^9.18.0",
+                "invariant": "^2.2.2",
+                "lodash": "^4.17.4"
             },
             "dependencies": {
                 "debug": {
@@ -1992,10 +1998,10 @@
             "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "esutils": "2.0.2",
-                "lodash": "4.17.4",
-                "to-fast-properties": "1.0.3"
+                "babel-runtime": "^6.26.0",
+                "esutils": "^2.0.2",
+                "lodash": "^4.17.4",
+                "to-fast-properties": "^1.0.3"
             },
             "dependencies": {
                 "lodash": {
@@ -2023,6 +2029,79 @@
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
             "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
             "dev": true
+        },
+        "base": {
+            "version": "0.11.2",
+            "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+            "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+            "dev": true,
+            "requires": {
+                "cache-base": "^1.0.1",
+                "class-utils": "^0.3.5",
+                "component-emitter": "^1.2.1",
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.1",
+                "mixin-deep": "^1.2.0",
+                "pascalcase": "^0.1.1"
+            },
+            "dependencies": {
+                "component-emitter": {
+                    "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+                    "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+                    "dev": true
+                },
+                "define-property": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                    "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^1.0.0"
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
+                    }
+                },
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
+                },
+                "kind-of": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+                    "dev": true
+                }
+            }
         },
         "base64-arraybuffer": {
             "version": "0.1.5",
@@ -2056,7 +2135,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "tweetnacl": "0.14.5"
+                "tweetnacl": "^0.14.3"
             }
         },
         "beeper": {
@@ -2092,7 +2171,7 @@
             "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.3"
+                "readable-stream": "^2.0.5"
             }
         },
         "blob": {
@@ -2107,7 +2186,7 @@
             "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3"
+                "inherits": "~2.0.0"
             }
         },
         "body-parser": {
@@ -2117,15 +2196,15 @@
             "dev": true,
             "requires": {
                 "bytes": "3.0.0",
-                "content-type": "1.0.4",
+                "content-type": "~1.0.4",
                 "debug": "2.6.9",
-                "depd": "1.1.1",
-                "http-errors": "1.6.2",
+                "depd": "~1.1.1",
+                "http-errors": "~1.6.2",
                 "iconv-lite": "0.4.19",
-                "on-finished": "2.3.0",
+                "on-finished": "~2.3.0",
                 "qs": "6.5.1",
                 "raw-body": "2.3.2",
-                "type-is": "1.6.15"
+                "type-is": "~1.6.15"
             },
             "dependencies": {
                 "debug": {
@@ -2146,7 +2225,7 @@
                         "depd": "1.1.1",
                         "inherits": "2.0.3",
                         "setprototypeof": "1.0.3",
-                        "statuses": "1.3.1"
+                        "statuses": ">= 1.3.1 < 2"
                     }
                 },
                 "ms": {
@@ -2175,7 +2254,7 @@
             "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
             "dev": true,
             "requires": {
-                "hoek": "2.16.3"
+                "hoek": "2.x.x"
             }
         },
         "bower": {
@@ -2190,10 +2269,10 @@
             "integrity": "sha1-lsFHIyQa5kZqnFLhbKoyYjqIOEM=",
             "dev": true,
             "requires": {
-                "deep-extend": "0.4.2",
-                "ext-name": "3.0.0",
-                "graceful-fs": "4.1.11",
-                "intersect": "1.0.1"
+                "deep-extend": "^0.4.0",
+                "ext-name": "^3.0.0",
+                "graceful-fs": "^4.1.3",
+                "intersect": "^1.0.1"
             }
         },
         "bower-logger": {
@@ -2208,15 +2287,15 @@
             "integrity": "sha1-g2TUJIrDT/DvGy8r9JpsYM4NgbY=",
             "dev": true,
             "requires": {
-                "ansi-align": "1.1.0",
-                "camelcase": "2.1.1",
-                "chalk": "1.1.3",
-                "cli-boxes": "1.0.0",
-                "filled-array": "1.1.0",
-                "object-assign": "4.1.1",
-                "repeating": "2.0.1",
-                "string-width": "1.0.2",
-                "widest-line": "1.0.0"
+                "ansi-align": "^1.1.0",
+                "camelcase": "^2.1.0",
+                "chalk": "^1.1.1",
+                "cli-boxes": "^1.0.0",
+                "filled-array": "^1.0.0",
+                "object-assign": "^4.0.1",
+                "repeating": "^2.0.0",
+                "string-width": "^1.0.1",
+                "widest-line": "^1.0.0"
             },
             "dependencies": {
                 "camelcase": {
@@ -2233,7 +2312,7 @@
             "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
             "dev": true,
             "requires": {
-                "balanced-match": "1.0.0",
+                "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -2243,9 +2322,9 @@
             "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
             "dev": true,
             "requires": {
-                "expand-range": "1.8.2",
-                "preserve": "0.2.0",
-                "repeat-element": "1.1.2"
+                "expand-range": "^1.8.1",
+                "preserve": "^0.2.0",
+                "repeat-element": "^1.1.2"
             }
         },
         "browser-capabilities": {
@@ -2254,8 +2333,8 @@
             "integrity": "sha512-huj8A1CGx28XvsgZvbkjWul+sR3NqQHr0FOvq6GcOWFJ7n4eKBOSNzmmPCRbA49bV5W8P7cbN5274fvsTEL7hw==",
             "dev": true,
             "requires": {
-                "@types/ua-parser-js": "0.7.32",
-                "ua-parser-js": "0.7.17"
+                "@types/ua-parser-js": "^0.7.31",
+                "ua-parser-js": "^0.7.14"
             },
             "dependencies": {
                 "ua-parser-js": {
@@ -2283,10 +2362,10 @@
                 "bs-recipes": "1.3.4",
                 "chokidar": "1.7.0",
                 "connect": "3.5.0",
-                "dev-ip": "1.0.1",
+                "dev-ip": "^1.0.1",
                 "easy-extender": "2.3.2",
                 "eazy-logger": "3.0.2",
-                "emitter-steward": "1.0.0",
+                "emitter-steward": "^1.0.0",
                 "fs-extra": "3.0.1",
                 "http-proxy": "1.15.2",
                 "immutable": "3.8.1",
@@ -2324,20 +2403,20 @@
                     "integrity": "sha1-gW4ahm1VmMzzTlWW3c4i2S2kkNQ=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "3.0.0",
-                        "cliui": "3.2.0",
-                        "decamelize": "1.2.0",
-                        "get-caller-file": "1.0.2",
-                        "os-locale": "1.4.0",
-                        "read-pkg-up": "1.0.1",
-                        "require-directory": "2.1.1",
-                        "require-main-filename": "1.0.1",
-                        "set-blocking": "2.0.0",
-                        "string-width": "1.0.2",
-                        "which-module": "1.0.0",
-                        "window-size": "0.2.0",
-                        "y18n": "3.2.1",
-                        "yargs-parser": "4.2.1"
+                        "camelcase": "^3.0.0",
+                        "cliui": "^3.2.0",
+                        "decamelize": "^1.1.1",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^1.4.0",
+                        "read-pkg-up": "^1.0.1",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^1.0.2",
+                        "which-module": "^1.0.0",
+                        "window-size": "^0.2.0",
+                        "y18n": "^3.2.1",
+                        "yargs-parser": "^4.1.0"
                     }
                 }
             }
@@ -2348,8 +2427,8 @@
             "integrity": "sha1-7BrWmknC4tS2RbGLHAbCmz2a+Os=",
             "dev": true,
             "requires": {
-                "etag": "1.8.1",
-                "fresh": "0.3.0"
+                "etag": "^1.7.0",
+                "fresh": "^0.3.0"
             }
         },
         "browser-sync-ui": {
@@ -2359,11 +2438,11 @@
             "dev": true,
             "requires": {
                 "async-each-series": "0.1.1",
-                "connect-history-api-fallback": "1.5.0",
-                "immutable": "3.8.1",
+                "connect-history-api-fallback": "^1.1.0",
+                "immutable": "^3.7.6",
                 "server-destroy": "1.0.1",
-                "stream-throttle": "0.1.3",
-                "weinre": "2.0.0-pre-I0Z7U9OV"
+                "stream-throttle": "^0.1.3",
+                "weinre": "^2.0.0-pre-I0Z7U9OV"
             }
         },
         "browserify-zlib": {
@@ -2372,7 +2451,7 @@
             "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
             "dev": true,
             "requires": {
-                "pako": "0.2.9"
+                "pako": "~0.2.0"
             }
         },
         "browserslist": {
@@ -2381,8 +2460,8 @@
             "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
             "dev": true,
             "requires": {
-                "caniuse-db": "1.0.30000772",
-                "electron-to-chromium": "1.3.27"
+                "caniuse-db": "^1.0.30000639",
+                "electron-to-chromium": "^1.2.7"
             }
         },
         "browserstack": {
@@ -2419,8 +2498,8 @@
             "integrity": "sha512-prjTDXzGEbTvCgDVEAKvOGpAqZnz5EmzJNiYi2L72TjNy+T91w3SbPgofnAsLXZZBqZigv+kN4oF5oEIyr6LPw==",
             "dev": true,
             "requires": {
-                "semver": "5.4.1",
-                "xtend": "4.0.1"
+                "semver": "^5.1.0",
+                "xtend": "^4.0.1"
             }
         },
         "busboy": {
@@ -2430,7 +2509,7 @@
             "dev": true,
             "requires": {
                 "dicer": "0.2.5",
-                "readable-stream": "1.1.14"
+                "readable-stream": "1.1.x"
             },
             "dependencies": {
                 "isarray": {
@@ -2445,10 +2524,10 @@
                     "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -2465,6 +2544,37 @@
             "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
             "dev": true
         },
+        "cache-base": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+            "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+            "dev": true,
+            "requires": {
+                "collection-visit": "^1.0.0",
+                "component-emitter": "^1.2.1",
+                "get-value": "^2.0.6",
+                "has-value": "^1.0.0",
+                "isobject": "^3.0.1",
+                "set-value": "^2.0.0",
+                "to-object-path": "^0.3.0",
+                "union-value": "^1.0.0",
+                "unset-value": "^1.0.0"
+            },
+            "dependencies": {
+                "component-emitter": {
+                    "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+                    "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+                    "dev": true
+                },
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
+                }
+            }
+        },
         "callsite": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
@@ -2477,8 +2587,8 @@
             "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
             "dev": true,
             "requires": {
-                "no-case": "2.3.2",
-                "upper-case": "1.1.3"
+                "no-case": "^2.2.0",
+                "upper-case": "^1.1.1"
             }
         },
         "camelcase": {
@@ -2493,8 +2603,8 @@
             "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
             "dev": true,
             "requires": {
-                "camelcase": "2.1.1",
-                "map-obj": "1.0.1"
+                "camelcase": "^2.0.0",
+                "map-obj": "^1.0.0"
             },
             "dependencies": {
                 "camelcase": {
@@ -2529,12 +2639,12 @@
             "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
             "dev": true,
             "requires": {
-                "assertion-error": "1.0.2",
-                "check-error": "1.0.2",
-                "deep-eql": "3.0.1",
-                "get-func-name": "2.0.0",
-                "pathval": "1.1.0",
-                "type-detect": "4.0.5"
+                "assertion-error": "^1.0.1",
+                "check-error": "^1.0.1",
+                "deep-eql": "^3.0.0",
+                "get-func-name": "^2.0.0",
+                "pathval": "^1.0.0",
+                "type-detect": "^4.0.0"
             }
         },
         "chalk": {
@@ -2543,11 +2653,11 @@
             "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
             "dev": true,
             "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
             }
         },
         "charenc": {
@@ -2568,15 +2678,15 @@
             "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
             "dev": true,
             "requires": {
-                "anymatch": "1.3.2",
-                "async-each": "1.0.1",
-                "fsevents": "1.1.3",
-                "glob-parent": "2.0.0",
-                "inherits": "2.0.3",
-                "is-binary-path": "1.0.1",
-                "is-glob": "2.0.1",
-                "path-is-absolute": "1.0.1",
-                "readdirp": "2.1.0"
+                "anymatch": "^1.3.0",
+                "async-each": "^1.0.0",
+                "fsevents": "^1.0.0",
+                "glob-parent": "^2.0.0",
+                "inherits": "^2.0.1",
+                "is-binary-path": "^1.0.0",
+                "is-glob": "^2.0.0",
+                "path-is-absolute": "^1.0.0",
+                "readdirp": "^2.0.0"
             }
         },
         "chownr": {
@@ -2591,7 +2701,7 @@
             "integrity": "sha1-gFeoKwD1P4Kl1ixQ74z/3sb6vDQ=",
             "dev": true,
             "requires": {
-                "object-assign": "2.1.1"
+                "object-assign": "^2.0.0"
             },
             "dependencies": {
                 "object-assign": {
@@ -2602,14 +2712,49 @@
                 }
             }
         },
+        "class-utils": {
+            "version": "0.3.6",
+            "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+            "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+            "dev": true,
+            "requires": {
+                "arr-union": "^3.1.0",
+                "define-property": "^0.2.5",
+                "isobject": "^3.0.0",
+                "static-extend": "^0.1.1"
+            },
+            "dependencies": {
+                "arr-union": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+                    "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+                    "dev": true
+                },
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^0.1.0"
+                    }
+                },
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
+                }
+            }
+        },
         "clean-css": {
             "version": "3.4.28",
             "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.28.tgz",
             "integrity": "sha1-vxlF6C/ICPVWlebd6uwBQA79A/8=",
             "dev": true,
             "requires": {
-                "commander": "2.8.1",
-                "source-map": "0.4.4"
+                "commander": "2.8.x",
+                "source-map": "0.4.x"
             },
             "dependencies": {
                 "commander": {
@@ -2618,7 +2763,7 @@
                     "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
                     "dev": true,
                     "requires": {
-                        "graceful-readlink": "1.0.1"
+                        "graceful-readlink": ">= 1.0.0"
                     }
                 },
                 "source-map": {
@@ -2627,7 +2772,7 @@
                     "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
                     "dev": true,
                     "requires": {
-                        "amdefine": "1.0.1"
+                        "amdefine": ">=0.0.4"
                     }
                 }
             }
@@ -2650,7 +2795,7 @@
             "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
             "dev": true,
             "requires": {
-                "restore-cursor": "1.0.1"
+                "restore-cursor": "^1.0.1"
             }
         },
         "cli-table": {
@@ -2674,9 +2819,9 @@
             "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
             "dev": true,
             "requires": {
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "wrap-ansi": "2.1.0"
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wrap-ansi": "^2.0.0"
             }
         },
         "clone": {
@@ -2703,9 +2848,9 @@
             "integrity": "sha1-pikNQT8hemEjL5XkWP84QYz7ARc=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "process-nextick-args": "1.0.7",
-                "through2": "2.0.3"
+                "inherits": "^2.0.1",
+                "process-nextick-args": "^1.0.6",
+                "through2": "^2.0.1"
             }
         },
         "co": {
@@ -2720,13 +2865,23 @@
             "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
             "dev": true
         },
+        "collection-visit": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+            "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+            "dev": true,
+            "requires": {
+                "map-visit": "^1.0.0",
+                "object-visit": "^1.0.0"
+            }
+        },
         "color-convert": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
             "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
             "dev": true,
             "requires": {
-                "color-name": "1.1.3"
+                "color-name": "^1.1.1"
             }
         },
         "color-name": {
@@ -2747,7 +2902,7 @@
             "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
             "dev": true,
             "requires": {
-                "delayed-stream": "1.0.0"
+                "delayed-stream": "~1.0.0"
             }
         },
         "command-line-args": {
@@ -2756,10 +2911,10 @@
             "integrity": "sha1-W9StReeYPlwTRJGOQCgO4mk8WsA=",
             "dev": true,
             "requires": {
-                "array-back": "1.0.4",
-                "feature-detect-es6": "1.3.1",
-                "find-replace": "1.0.3",
-                "typical": "2.6.1"
+                "array-back": "^1.0.4",
+                "feature-detect-es6": "^1.3.1",
+                "find-replace": "^1.0.2",
+                "typical": "^2.6.0"
             }
         },
         "command-line-commands": {
@@ -2768,8 +2923,8 @@
             "integrity": "sha1-A0+bFntRiK+9z2su+7FQ/IRCwys=",
             "dev": true,
             "requires": {
-                "array-back": "1.0.4",
-                "feature-detect-es6": "1.3.1"
+                "array-back": "^1.0.3",
+                "feature-detect-es6": "^1.3.1"
             }
         },
         "command-line-usage": {
@@ -2778,11 +2933,11 @@
             "integrity": "sha1-tqIJeMGzg0d/XBGlKUKLiAv+D00=",
             "dev": true,
             "requires": {
-                "ansi-escape-sequences": "3.0.0",
-                "array-back": "1.0.4",
-                "feature-detect-es6": "1.3.1",
-                "table-layout": "0.3.0",
-                "typical": "2.6.1"
+                "ansi-escape-sequences": "^3.0.0",
+                "array-back": "^1.0.3",
+                "feature-detect-es6": "^1.3.1",
+                "table-layout": "^0.3.0",
+                "typical": "^2.6.0"
             }
         },
         "commander": {
@@ -2821,10 +2976,10 @@
             "integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
             "dev": true,
             "requires": {
-                "buffer-crc32": "0.2.13",
-                "crc32-stream": "2.0.0",
-                "normalize-path": "2.1.1",
-                "readable-stream": "2.3.3"
+                "buffer-crc32": "^0.2.1",
+                "crc32-stream": "^2.0.0",
+                "normalize-path": "^2.0.0",
+                "readable-stream": "^2.0.0"
             }
         },
         "compressible": {
@@ -2833,7 +2988,7 @@
             "integrity": "sha1-xZpcmdt2dn6YdlAOJx72OzSTvWY=",
             "dev": true,
             "requires": {
-                "mime-db": "1.30.0"
+                "mime-db": ">= 1.30.0 < 2"
             }
         },
         "compression": {
@@ -2842,13 +2997,13 @@
             "integrity": "sha1-7/JgPvwuIs+G810uuTWJ+YdTc9s=",
             "dev": true,
             "requires": {
-                "accepts": "1.3.4",
+                "accepts": "~1.3.4",
                 "bytes": "3.0.0",
-                "compressible": "2.0.12",
+                "compressible": "~2.0.11",
                 "debug": "2.6.9",
-                "on-headers": "1.0.1",
+                "on-headers": "~1.0.1",
                 "safe-buffer": "5.1.1",
-                "vary": "1.1.2"
+                "vary": "~1.1.2"
             },
             "dependencies": {
                 "debug": {
@@ -2880,9 +3035,9 @@
             "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.3",
-                "typedarray": "0.0.6"
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.2.2",
+                "typedarray": "^0.0.6"
             }
         },
         "concat-with-sourcemaps": {
@@ -2891,7 +3046,7 @@
             "integrity": "sha1-9Vs74q60dgGxCi1SWcz7cP0vHdY=",
             "dev": true,
             "requires": {
-                "source-map": "0.5.7"
+                "source-map": "^0.5.1"
             }
         },
         "configstore": {
@@ -2900,15 +3055,15 @@
             "integrity": "sha1-c3o6cDbpiGECqmCZ5HuzOrGroaE=",
             "dev": true,
             "requires": {
-                "dot-prop": "3.0.0",
-                "graceful-fs": "4.1.11",
-                "mkdirp": "0.5.1",
-                "object-assign": "4.1.1",
-                "os-tmpdir": "1.0.2",
-                "osenv": "0.1.4",
-                "uuid": "2.0.3",
-                "write-file-atomic": "1.3.4",
-                "xdg-basedir": "2.0.0"
+                "dot-prop": "^3.0.0",
+                "graceful-fs": "^4.1.2",
+                "mkdirp": "^0.5.0",
+                "object-assign": "^4.0.1",
+                "os-tmpdir": "^1.0.0",
+                "osenv": "^0.1.0",
+                "uuid": "^2.0.1",
+                "write-file-atomic": "^1.1.2",
+                "xdg-basedir": "^2.0.0"
             },
             "dependencies": {
                 "minimist": {
@@ -2940,9 +3095,9 @@
             "integrity": "sha1-s1dSWgtMH1BZnNmD4dnv7qlncZg=",
             "dev": true,
             "requires": {
-                "debug": "2.2.0",
+                "debug": "~2.2.0",
                 "finalhandler": "0.5.0",
-                "parseurl": "1.3.2",
+                "parseurl": "~1.3.1",
                 "utils-merge": "1.0.0"
             }
         },
@@ -2988,6 +3143,12 @@
             "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
             "dev": true
         },
+        "copy-descriptor": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+            "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+            "dev": true
+        },
         "core-js": {
             "version": "2.5.1",
             "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
@@ -3012,8 +3173,8 @@
             "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
             "dev": true,
             "requires": {
-                "crc": "3.5.0",
-                "readable-stream": "2.3.3"
+                "crc": "^3.4.4",
+                "readable-stream": "^2.0.0"
             },
             "dependencies": {
                 "crc": {
@@ -3030,7 +3191,7 @@
             "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
             "dev": true,
             "requires": {
-                "capture-stack-trace": "1.0.0"
+                "capture-stack-trace": "^1.0.0"
             }
         },
         "cross-spawn": {
@@ -3039,8 +3200,8 @@
             "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
             "dev": true,
             "requires": {
-                "lru-cache": "4.1.1",
-                "which": "1.3.0"
+                "lru-cache": "^4.0.1",
+                "which": "^1.2.9"
             },
             "dependencies": {
                 "lru-cache": {
@@ -3049,8 +3210,8 @@
                     "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
                     "dev": true,
                     "requires": {
-                        "pseudomap": "1.0.2",
-                        "yallist": "2.1.2"
+                        "pseudomap": "^1.0.2",
+                        "yallist": "^2.1.2"
                     }
                 }
             }
@@ -3067,7 +3228,7 @@
             "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
             "dev": true,
             "requires": {
-                "boom": "2.10.1"
+                "boom": "2.x.x"
             }
         },
         "crypto-random-string": {
@@ -3083,11 +3244,11 @@
             "integrity": "sha512-4cFIlPuteucnKCZa68rB/Pd3uV+DDc7UwP3PVmlEwxTi92WdesRc9Ddbzw6/+RunF09tNK3sSkLERBFO1DjKcg==",
             "dev": true,
             "requires": {
-                "command-line-args": "3.0.5",
-                "command-line-usage": "3.0.8",
-                "dom5": "2.3.0",
-                "parse5": "2.2.3",
-                "shady-css-parser": "0.1.0"
+                "command-line-args": "^3.0.1",
+                "command-line-usage": "^3.0.5",
+                "dom5": "^2.0.1",
+                "parse5": "^2.2.3",
+                "shady-css-parser": "^0.1.0"
             }
         },
         "css-what": {
@@ -3108,7 +3269,7 @@
             "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
             "dev": true,
             "requires": {
-                "array-find-index": "1.0.2"
+                "array-find-index": "^1.0.1"
             }
         },
         "cycle": {
@@ -3129,7 +3290,7 @@
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -3161,13 +3322,19 @@
             "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
             "dev": true
         },
+        "decode-uri-component": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+            "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+            "dev": true
+        },
         "deep-eql": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
             "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
             "dev": true,
             "requires": {
-                "type-detect": "4.0.5"
+                "type-detect": "^4.0.0"
             }
         },
         "deep-extend": {
@@ -3188,7 +3355,60 @@
             "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
             "dev": true,
             "requires": {
-                "clone": "1.0.3"
+                "clone": "^1.0.2"
+            }
+        },
+        "define-property": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+            "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+            "dev": true,
+            "requires": {
+                "is-descriptor": "^1.0.2",
+                "isobject": "^3.0.1"
+            },
+            "dependencies": {
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
+                    }
+                },
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
+                },
+                "kind-of": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+                    "dev": true
+                }
             }
         },
         "del": {
@@ -3197,12 +3417,12 @@
             "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
             "dev": true,
             "requires": {
-                "globby": "6.1.0",
-                "is-path-cwd": "1.0.0",
-                "is-path-in-cwd": "1.0.0",
-                "p-map": "1.2.0",
-                "pify": "3.0.0",
-                "rimraf": "2.6.2"
+                "globby": "^6.1.0",
+                "is-path-cwd": "^1.0.0",
+                "is-path-in-cwd": "^1.0.0",
+                "p-map": "^1.1.1",
+                "pify": "^3.0.0",
+                "rimraf": "^2.2.8"
             },
             "dependencies": {
                 "pify": {
@@ -3255,7 +3475,7 @@
             "integrity": "sha1-STXe39lIhkjgBrASlWbpOGcR6mM=",
             "dev": true,
             "requires": {
-                "fs-exists-sync": "0.1.0"
+                "fs-exists-sync": "^0.1.0"
             }
         },
         "detect-indent": {
@@ -3264,7 +3484,7 @@
             "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
             "dev": true,
             "requires": {
-                "repeating": "2.0.1"
+                "repeating": "^2.0.0"
             }
         },
         "detect-node": {
@@ -3285,7 +3505,7 @@
             "integrity": "sha1-WZbAhrszIYyBLAkL3cCc0S+stw8=",
             "dev": true,
             "requires": {
-                "readable-stream": "1.1.14",
+                "readable-stream": "1.1.x",
                 "streamsearch": "0.1.2"
             },
             "dependencies": {
@@ -3301,10 +3521,10 @@
                     "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -3327,7 +3547,7 @@
             "integrity": "sha512-y0tm5Pq6ywp3qSTZ1vPgVdAnbDEoeoc5wlOHXoY1c4Wug/a7JvqHIl7BTvwodaHmejWkK/9dSb3sCYfyo/om8A==",
             "dev": true,
             "requires": {
-                "esutils": "2.0.2"
+                "esutils": "^2.0.2"
             }
         },
         "dom-urls": {
@@ -3336,7 +3556,7 @@
             "integrity": "sha1-AB3fgWKM0ecGElxxdvU8zsVdkY4=",
             "dev": true,
             "requires": {
-                "urijs": "1.19.0"
+                "urijs": "^1.16.1"
             }
         },
         "dom5": {
@@ -3345,11 +3565,11 @@
             "integrity": "sha1-+CBJdb0NrLvltYqKk//B/tD/zSo=",
             "dev": true,
             "requires": {
-                "@types/clone": "0.1.30",
-                "@types/node": "6.0.92",
-                "@types/parse5": "2.2.34",
-                "clone": "2.1.1",
-                "parse5": "2.2.3"
+                "@types/clone": "^0.1.29",
+                "@types/node": "^6.0.0",
+                "@types/parse5": "^2.2.32",
+                "clone": "^2.1.0",
+                "parse5": "^2.2.2"
             },
             "dependencies": {
                 "@types/node": {
@@ -3372,7 +3592,7 @@
             "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
             "dev": true,
             "requires": {
-                "is-obj": "1.0.1"
+                "is-obj": "^1.0.0"
             }
         },
         "duplexer2": {
@@ -3381,7 +3601,7 @@
             "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
             "dev": true,
             "requires": {
-                "readable-stream": "1.1.14"
+                "readable-stream": "~1.1.9"
             },
             "dependencies": {
                 "isarray": {
@@ -3396,10 +3616,10 @@
                     "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -3422,10 +3642,10 @@
             "integrity": "sha512-j5goxHTwVED1Fpe5hh3q9R93Kip0Bg2KVAt4f8CEYM3UEwYcPSvWbXaUQOzdX/HtiNomipv+gU7ASQPDbV7pGQ==",
             "dev": true,
             "requires": {
-                "end-of-stream": "1.4.0",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.3",
-                "stream-shift": "1.0.0"
+                "end-of-stream": "^1.0.0",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0",
+                "stream-shift": "^1.0.0"
             },
             "dependencies": {
                 "end-of-stream": {
@@ -3434,7 +3654,7 @@
                     "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
                     "dev": true,
                     "requires": {
-                        "once": "1.4.0"
+                        "once": "^1.4.0"
                     }
                 },
                 "once": {
@@ -3443,7 +3663,7 @@
                     "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                     "dev": true,
                     "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                     }
                 }
             }
@@ -3454,7 +3674,7 @@
             "integrity": "sha1-PTJI/r4rFZYHMW2PnPSRwWZIIh0=",
             "dev": true,
             "requires": {
-                "lodash": "3.10.1"
+                "lodash": "^3.10.1"
             }
         },
         "eazy-logger": {
@@ -3463,7 +3683,7 @@
             "integrity": "sha1-oyWqXlPROiIliJsqxBE7K5Y29Pw=",
             "dev": true,
             "requires": {
-                "tfunk": "3.1.0"
+                "tfunk": "^3.0.1"
             }
         },
         "ecc-jsbn": {
@@ -3473,7 +3693,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "jsbn": "0.1.1"
+                "jsbn": "~0.1.0"
             }
         },
         "editions": {
@@ -3518,7 +3738,7 @@
             "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
             "dev": true,
             "requires": {
-                "once": "1.3.3"
+                "once": "~1.3.0"
             }
         },
         "ends-with": {
@@ -3547,7 +3767,7 @@
                     "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
                     "dev": true,
                     "requires": {
-                        "mime-types": "2.1.17",
+                        "mime-types": "~2.1.11",
                         "negotiator": "0.6.1"
                     }
                 },
@@ -3648,8 +3868,8 @@
             "integrity": "sha512-9DkWC4v8BoPszH7IcK88IOKUGT9LnScGzL7PmNTS5wuol5p6aGUF1kqwmlSAHtXdz1dL7xRK6nWmkLLYFaWtBw==",
             "dev": true,
             "requires": {
-                "plugin-error": "1.0.1",
-                "through2": "2.0.3"
+                "plugin-error": "^1.0.1",
+                "through2": "^2.0.3"
             },
             "dependencies": {
                 "arr-diff": {
@@ -3670,8 +3890,8 @@
                     "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
                     "dev": true,
                     "requires": {
-                        "assign-symbols": "1.0.0",
-                        "is-extendable": "1.0.1"
+                        "assign-symbols": "^1.0.0",
+                        "is-extendable": "^1.0.1"
                     }
                 },
                 "is-extendable": {
@@ -3680,7 +3900,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "2.0.4"
+                        "is-plain-object": "^2.0.4"
                     }
                 },
                 "plugin-error": {
@@ -3689,10 +3909,10 @@
                     "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
                     "dev": true,
                     "requires": {
-                        "ansi-colors": "1.1.0",
-                        "arr-diff": "4.0.0",
-                        "arr-union": "3.1.0",
-                        "extend-shallow": "3.0.2"
+                        "ansi-colors": "^1.0.1",
+                        "arr-diff": "^4.0.0",
+                        "arr-union": "^3.1.0",
+                        "extend-shallow": "^3.0.2"
                     }
                 }
             }
@@ -3703,8 +3923,8 @@
             "integrity": "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=",
             "dev": true,
             "requires": {
-                "string-template": "0.2.1",
-                "xtend": "4.0.1"
+                "string-template": "~0.2.1",
+                "xtend": "~4.0.0"
             }
         },
         "error-ex": {
@@ -3713,7 +3933,7 @@
             "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
             "dev": true,
             "requires": {
-                "is-arrayish": "0.2.1"
+                "is-arrayish": "^0.2.1"
             }
         },
         "es6-promise": {
@@ -3740,11 +3960,11 @@
             "integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
             "dev": true,
             "requires": {
-                "esprima": "3.1.3",
-                "estraverse": "4.2.0",
-                "esutils": "2.0.2",
-                "optionator": "0.8.2",
-                "source-map": "0.5.7"
+                "esprima": "^3.1.3",
+                "estraverse": "^4.2.0",
+                "esutils": "^2.0.2",
+                "optionator": "^0.8.1",
+                "source-map": "~0.5.6"
             },
             "dependencies": {
                 "esprima": {
@@ -3761,8 +3981,8 @@
             "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
             "dev": true,
             "requires": {
-                "acorn": "5.2.1",
-                "acorn-jsx": "3.0.1"
+                "acorn": "^5.2.1",
+                "acorn-jsx": "^3.0.0"
             }
         },
         "esprima": {
@@ -3802,13 +4022,13 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "cross-spawn": "5.1.0",
-                "get-stream": "3.0.0",
-                "is-stream": "1.1.0",
-                "npm-run-path": "2.0.2",
-                "p-finally": "1.0.0",
-                "signal-exit": "3.0.2",
-                "strip-eof": "1.0.0"
+                "cross-spawn": "^5.0.1",
+                "get-stream": "^3.0.0",
+                "is-stream": "^1.1.0",
+                "npm-run-path": "^2.0.0",
+                "p-finally": "^1.0.0",
+                "signal-exit": "^3.0.0",
+                "strip-eof": "^1.0.0"
             },
             "dependencies": {
                 "cross-spawn": {
@@ -3818,9 +4038,9 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "lru-cache": "4.1.1",
-                        "shebang-command": "1.2.0",
-                        "which": "1.3.0"
+                        "lru-cache": "^4.0.1",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
                     }
                 },
                 "lru-cache": {
@@ -3830,8 +4050,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "pseudomap": "1.0.2",
-                        "yallist": "2.1.2"
+                        "pseudomap": "^1.0.2",
+                        "yallist": "^2.1.2"
                     }
                 }
             }
@@ -3848,7 +4068,7 @@
             "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
             "dev": true,
             "requires": {
-                "is-posix-bracket": "0.1.1"
+                "is-posix-bracket": "^0.1.0"
             }
         },
         "expand-range": {
@@ -3857,7 +4077,7 @@
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
             "dev": true,
             "requires": {
-                "fill-range": "2.2.3"
+                "fill-range": "^2.1.0"
             }
         },
         "expand-tilde": {
@@ -3866,7 +4086,7 @@
             "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
             "dev": true,
             "requires": {
-                "os-homedir": "1.0.2"
+                "os-homedir": "^1.0.1"
             }
         },
         "express": {
@@ -3875,10 +4095,10 @@
             "integrity": "sha1-TOjqHzY15p5J8Ou0l7aksKUc5vA=",
             "dev": true,
             "requires": {
-                "connect": "1.9.2",
+                "connect": "1.x",
                 "mime": "1.2.4",
                 "mkdirp": "0.3.0",
-                "qs": "0.4.2"
+                "qs": "0.4.x"
             },
             "dependencies": {
                 "connect": {
@@ -3887,9 +4107,9 @@
                     "integrity": "sha1-QogKIulDiuWait105Df1iujlKAc=",
                     "dev": true,
                     "requires": {
-                        "formidable": "1.0.17",
-                        "mime": "1.2.4",
-                        "qs": "0.4.2"
+                        "formidable": "1.0.x",
+                        "mime": ">= 0.0.1",
+                        "qs": ">= 0.4.0"
                     }
                 },
                 "qs": {
@@ -3906,7 +4126,7 @@
             "integrity": "sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==",
             "dev": true,
             "requires": {
-                "mime-db": "1.30.0"
+                "mime-db": "^1.28.0"
             }
         },
         "ext-name": {
@@ -3915,10 +4135,10 @@
             "integrity": "sha1-B+RBhzfLH1E8MsbqSNi4yOBHGrs=",
             "dev": true,
             "requires": {
-                "ends-with": "0.2.0",
-                "ext-list": "2.2.2",
-                "meow": "3.7.0",
-                "sort-keys-length": "1.0.1"
+                "ends-with": "^0.2.0",
+                "ext-list": "^2.0.0",
+                "meow": "^3.1.0",
+                "sort-keys-length": "^1.0.0"
             }
         },
         "extend": {
@@ -3933,7 +4153,7 @@
             "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
             "dev": true,
             "requires": {
-                "kind-of": "1.1.0"
+                "kind-of": "^1.1.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -3950,9 +4170,9 @@
             "integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
             "dev": true,
             "requires": {
-                "extend": "3.0.1",
-                "spawn-sync": "1.0.15",
-                "tmp": "0.0.29"
+                "extend": "^3.0.0",
+                "spawn-sync": "^1.0.15",
+                "tmp": "^0.0.29"
             }
         },
         "extglob": {
@@ -3961,7 +4181,7 @@
             "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
             "dev": true,
             "requires": {
-                "is-extglob": "1.0.0"
+                "is-extglob": "^1.0.0"
             }
         },
         "extsprintf": {
@@ -3982,8 +4202,8 @@
             "integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "time-stamp": "1.1.0"
+                "chalk": "^1.1.1",
+                "time-stamp": "^1.0.0"
             }
         },
         "fast-levenshtein": {
@@ -3999,7 +4219,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "pend": "1.2.0"
+                "pend": "~1.2.0"
             }
         },
         "feature-detect-es6": {
@@ -4008,7 +4228,7 @@
             "integrity": "sha1-+IhzavnLDJH1VmO/pHYuuW7nBH8=",
             "dev": true,
             "requires": {
-                "array-back": "1.0.4"
+                "array-back": "^1.0.3"
             }
         },
         "figures": {
@@ -4017,8 +4237,8 @@
             "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
             "dev": true,
             "requires": {
-                "escape-string-regexp": "1.0.5",
-                "object-assign": "4.1.1"
+                "escape-string-regexp": "^1.0.5",
+                "object-assign": "^4.1.0"
             }
         },
         "filename-regex": {
@@ -4039,11 +4259,11 @@
             "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
             "dev": true,
             "requires": {
-                "is-number": "2.1.0",
-                "isobject": "2.1.0",
-                "randomatic": "1.1.7",
-                "repeat-element": "1.1.2",
-                "repeat-string": "1.6.1"
+                "is-number": "^2.1.0",
+                "isobject": "^2.0.0",
+                "randomatic": "^1.1.3",
+                "repeat-element": "^1.1.2",
+                "repeat-string": "^1.5.2"
             }
         },
         "filled-array": {
@@ -4058,11 +4278,11 @@
             "integrity": "sha1-6VCKvs6bbbqHGmlCodeRG5GRGsc=",
             "dev": true,
             "requires": {
-                "debug": "2.2.0",
-                "escape-html": "1.0.3",
-                "on-finished": "2.3.0",
-                "statuses": "1.3.1",
-                "unpipe": "1.0.0"
+                "debug": "~2.2.0",
+                "escape-html": "~1.0.3",
+                "on-finished": "~2.3.0",
+                "statuses": "~1.3.0",
+                "unpipe": "~1.0.0"
             }
         },
         "find-index": {
@@ -4077,7 +4297,7 @@
             "integrity": "sha1-2whKbL+ZVk2Zhprnn73s9m6KGFw=",
             "dev": true,
             "requires": {
-                "async": "0.2.10"
+                "async": "~0.2.9"
             },
             "dependencies": {
                 "async": {
@@ -4094,8 +4314,8 @@
             "integrity": "sha1-uI5zZNLZyVlVnziMZmcNYTBEH6A=",
             "dev": true,
             "requires": {
-                "array-back": "1.0.4",
-                "test-value": "2.1.0"
+                "array-back": "^1.0.4",
+                "test-value": "^2.1.0"
             }
         },
         "find-up": {
@@ -4104,8 +4324,8 @@
             "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
             "dev": true,
             "requires": {
-                "path-exists": "2.1.0",
-                "pinkie-promise": "2.0.1"
+                "path-exists": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
             }
         },
         "findup-sync": {
@@ -4114,23 +4334,23 @@
             "integrity": "sha1-QAQ5Kee8YK3wt/SCfExudaDeyhI=",
             "dev": true,
             "requires": {
-                "detect-file": "0.1.0",
-                "is-glob": "2.0.1",
-                "micromatch": "2.3.11",
-                "resolve-dir": "0.1.1"
+                "detect-file": "^0.1.0",
+                "is-glob": "^2.0.1",
+                "micromatch": "^2.3.7",
+                "resolve-dir": "^0.1.0"
             }
         },
         "fined": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/fined/-/fined-1.1.0.tgz",
-            "integrity": "sha1-s33IRLdqL15wgeiE98CuNE8VNHY=",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/fined/-/fined-1.1.1.tgz",
+            "integrity": "sha512-jQp949ZmEbiYHk3gkbdtpJ0G1+kgtLQBNdP5edFP7Fh+WAYceLQz6yO1SBj72Xkg8GVyTB3bBzAYrHJVh5Xd5g==",
             "dev": true,
             "requires": {
-                "expand-tilde": "2.0.2",
-                "is-plain-object": "2.0.4",
-                "object.defaults": "1.1.0",
-                "object.pick": "1.3.0",
-                "parse-filepath": "1.0.1"
+                "expand-tilde": "^2.0.2",
+                "is-plain-object": "^2.0.3",
+                "object.defaults": "^1.1.0",
+                "object.pick": "^1.2.0",
+                "parse-filepath": "^1.0.1"
             },
             "dependencies": {
                 "expand-tilde": {
@@ -4139,7 +4359,7 @@
                     "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
                     "dev": true,
                     "requires": {
-                        "homedir-polyfill": "1.0.1"
+                        "homedir-polyfill": "^1.0.1"
                     }
                 }
             }
@@ -4151,9 +4371,9 @@
             "dev": true
         },
         "flagged-respawn": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.2.tgz",
-            "integrity": "sha1-/xke3c1wiKZ1smEP/8l2vpuAdLU=",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
+            "integrity": "sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q==",
             "dev": true
         },
         "follow-redirects": {
@@ -4162,8 +4382,8 @@
             "integrity": "sha1-NLkLqyqRGqNHVx2pDyK9NuzYqRk=",
             "dev": true,
             "requires": {
-                "debug": "2.2.0",
-                "stream-consume": "0.1.0"
+                "debug": "^2.2.0",
+                "stream-consume": "^0.1.0"
             }
         },
         "for-in": {
@@ -4178,7 +4398,7 @@
             "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
             "dev": true,
             "requires": {
-                "for-in": "1.0.2"
+                "for-in": "^1.0.1"
             }
         },
         "forever-agent": {
@@ -4199,9 +4419,9 @@
             "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
             "dev": true,
             "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.5",
-                "mime-types": "2.1.17"
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.5",
+                "mime-types": "^2.1.12"
             }
         },
         "formatio": {
@@ -4210,7 +4430,7 @@
             "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
             "dev": true,
             "requires": {
-                "samsam": "1.3.0"
+                "samsam": "1.x"
             }
         },
         "formidable": {
@@ -4224,6 +4444,15 @@
             "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
             "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
             "dev": true
+        },
+        "fragment-cache": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+            "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+            "dev": true,
+            "requires": {
+                "map-cache": "^0.2.2"
+            }
         },
         "freeport": {
             "version": "1.0.5",
@@ -4250,9 +4479,9 @@
             "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "jsonfile": "3.0.1",
-                "universalify": "0.1.1"
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^3.0.0",
+                "universalify": "^0.1.0"
             }
         },
         "fs.realpath": {
@@ -4268,8 +4497,8 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "nan": "2.8.0",
-                "node-pre-gyp": "0.6.39"
+                "nan": "^2.3.0",
+                "node-pre-gyp": "^0.6.39"
             },
             "dependencies": {
                 "abbrev": {
@@ -4284,8 +4513,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "co": "4.6.0",
-                        "json-stable-stringify": "1.0.1"
+                        "co": "^4.6.0",
+                        "json-stable-stringify": "^1.0.1"
                     }
                 },
                 "ansi-regex": {
@@ -4305,8 +4534,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "delegates": "1.0.0",
-                        "readable-stream": "2.2.9"
+                        "delegates": "^1.0.0",
+                        "readable-stream": "^2.0.6"
                     }
                 },
                 "asn1": {
@@ -4350,7 +4579,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "tweetnacl": "0.14.5"
+                        "tweetnacl": "^0.14.3"
                     }
                 },
                 "block-stream": {
@@ -4358,7 +4587,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "inherits": "2.0.3"
+                        "inherits": "~2.0.0"
                     }
                 },
                 "boom": {
@@ -4366,7 +4595,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "hoek": "2.16.3"
+                        "hoek": "2.x.x"
                     }
                 },
                 "brace-expansion": {
@@ -4374,7 +4603,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "balanced-match": "0.4.2",
+                        "balanced-match": "^0.4.1",
                         "concat-map": "0.0.1"
                     }
                 },
@@ -4405,7 +4634,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "delayed-stream": "1.0.0"
+                        "delayed-stream": "~1.0.0"
                     }
                 },
                 "concat-map": {
@@ -4428,7 +4657,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "boom": "2.10.1"
+                        "boom": "2.x.x"
                     }
                 },
                 "dashdash": {
@@ -4437,7 +4666,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "assert-plus": "1.0.0"
+                        "assert-plus": "^1.0.0"
                     },
                     "dependencies": {
                         "assert-plus": {
@@ -4486,7 +4715,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "jsbn": "0.1.1"
+                        "jsbn": "~0.1.0"
                     }
                 },
                 "extend": {
@@ -4512,9 +4741,9 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "asynckit": "0.4.0",
-                        "combined-stream": "1.0.5",
-                        "mime-types": "2.1.15"
+                        "asynckit": "^0.4.0",
+                        "combined-stream": "^1.0.5",
+                        "mime-types": "^2.1.12"
                     }
                 },
                 "fs.realpath": {
@@ -4527,10 +4756,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "inherits": "2.0.3",
-                        "mkdirp": "0.5.1",
-                        "rimraf": "2.6.1"
+                        "graceful-fs": "^4.1.2",
+                        "inherits": "~2.0.0",
+                        "mkdirp": ">=0.5 0",
+                        "rimraf": "2"
                     }
                 },
                 "fstream-ignore": {
@@ -4539,9 +4768,9 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "fstream": "1.0.11",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4"
+                        "fstream": "^1.0.0",
+                        "inherits": "2",
+                        "minimatch": "^3.0.0"
                     }
                 },
                 "gauge": {
@@ -4550,14 +4779,14 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "aproba": "1.1.1",
-                        "console-control-strings": "1.1.0",
-                        "has-unicode": "2.0.1",
-                        "object-assign": "4.1.1",
-                        "signal-exit": "3.0.2",
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1",
-                        "wide-align": "1.1.2"
+                        "aproba": "^1.0.3",
+                        "console-control-strings": "^1.0.0",
+                        "has-unicode": "^2.0.0",
+                        "object-assign": "^4.1.0",
+                        "signal-exit": "^3.0.0",
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1",
+                        "wide-align": "^1.1.0"
                     }
                 },
                 "getpass": {
@@ -4566,7 +4795,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "assert-plus": "1.0.0"
+                        "assert-plus": "^1.0.0"
                     },
                     "dependencies": {
                         "assert-plus": {
@@ -4582,12 +4811,12 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "graceful-fs": {
@@ -4607,8 +4836,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "ajv": "4.11.8",
-                        "har-schema": "1.0.5"
+                        "ajv": "^4.9.1",
+                        "har-schema": "^1.0.5"
                     }
                 },
                 "has-unicode": {
@@ -4622,10 +4851,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "boom": "2.10.1",
-                        "cryptiles": "2.0.5",
-                        "hoek": "2.16.3",
-                        "sntp": "1.0.9"
+                        "boom": "2.x.x",
+                        "cryptiles": "2.x.x",
+                        "hoek": "2.x.x",
+                        "sntp": "1.x.x"
                     }
                 },
                 "hoek": {
@@ -4639,9 +4868,9 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "assert-plus": "0.2.0",
-                        "jsprim": "1.4.0",
-                        "sshpk": "1.13.0"
+                        "assert-plus": "^0.2.0",
+                        "jsprim": "^1.2.2",
+                        "sshpk": "^1.7.0"
                     }
                 },
                 "inflight": {
@@ -4649,8 +4878,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                     }
                 },
                 "inherits": {
@@ -4669,7 +4898,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "number-is-nan": "1.0.1"
+                        "number-is-nan": "^1.0.0"
                     }
                 },
                 "is-typedarray": {
@@ -4695,7 +4924,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "jsbn": "0.1.1"
+                        "jsbn": "~0.1.0"
                     }
                 },
                 "jsbn": {
@@ -4716,7 +4945,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "jsonify": "0.0.0"
+                        "jsonify": "~0.0.0"
                     }
                 },
                 "json-stringify-safe": {
@@ -4761,7 +4990,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "mime-db": "1.27.0"
+                        "mime-db": "~1.27.0"
                     }
                 },
                 "minimatch": {
@@ -4769,7 +4998,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "brace-expansion": "1.1.7"
+                        "brace-expansion": "^1.1.7"
                     }
                 },
                 "minimist": {
@@ -4797,17 +5026,17 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "detect-libc": "1.0.2",
+                        "detect-libc": "^1.0.2",
                         "hawk": "3.1.3",
-                        "mkdirp": "0.5.1",
-                        "nopt": "4.0.1",
-                        "npmlog": "4.1.0",
-                        "rc": "1.2.1",
+                        "mkdirp": "^0.5.1",
+                        "nopt": "^4.0.1",
+                        "npmlog": "^4.0.2",
+                        "rc": "^1.1.7",
                         "request": "2.81.0",
-                        "rimraf": "2.6.1",
-                        "semver": "5.3.0",
-                        "tar": "2.2.1",
-                        "tar-pack": "3.4.0"
+                        "rimraf": "^2.6.1",
+                        "semver": "^5.3.0",
+                        "tar": "^2.2.1",
+                        "tar-pack": "^3.4.0"
                     }
                 },
                 "nopt": {
@@ -4816,8 +5045,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "abbrev": "1.1.0",
-                        "osenv": "0.1.4"
+                        "abbrev": "1",
+                        "osenv": "^0.1.4"
                     }
                 },
                 "npmlog": {
@@ -4826,10 +5055,10 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "are-we-there-yet": "1.1.4",
-                        "console-control-strings": "1.1.0",
-                        "gauge": "2.7.4",
-                        "set-blocking": "2.0.0"
+                        "are-we-there-yet": "~1.1.2",
+                        "console-control-strings": "~1.1.0",
+                        "gauge": "~2.7.3",
+                        "set-blocking": "~2.0.0"
                     }
                 },
                 "number-is-nan": {
@@ -4854,7 +5083,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                     }
                 },
                 "os-homedir": {
@@ -4875,8 +5104,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "os-homedir": "1.0.2",
-                        "os-tmpdir": "1.0.2"
+                        "os-homedir": "^1.0.0",
+                        "os-tmpdir": "^1.0.0"
                     }
                 },
                 "path-is-absolute": {
@@ -4913,10 +5142,10 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "deep-extend": "0.4.2",
-                        "ini": "1.3.4",
-                        "minimist": "1.2.0",
-                        "strip-json-comments": "2.0.1"
+                        "deep-extend": "~0.4.0",
+                        "ini": "~1.3.0",
+                        "minimist": "^1.2.0",
+                        "strip-json-comments": "~2.0.1"
                     },
                     "dependencies": {
                         "minimist": {
@@ -4932,13 +5161,13 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "buffer-shims": "1.0.0",
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "1.0.7",
-                        "string_decoder": "1.0.1",
-                        "util-deprecate": "1.0.2"
+                        "buffer-shims": "~1.0.0",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~1.0.6",
+                        "string_decoder": "~1.0.0",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "request": {
@@ -4947,28 +5176,28 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "aws-sign2": "0.6.0",
-                        "aws4": "1.6.0",
-                        "caseless": "0.12.0",
-                        "combined-stream": "1.0.5",
-                        "extend": "3.0.1",
-                        "forever-agent": "0.6.1",
-                        "form-data": "2.1.4",
-                        "har-validator": "4.2.1",
-                        "hawk": "3.1.3",
-                        "http-signature": "1.1.1",
-                        "is-typedarray": "1.0.0",
-                        "isstream": "0.1.2",
-                        "json-stringify-safe": "5.0.1",
-                        "mime-types": "2.1.15",
-                        "oauth-sign": "0.8.2",
-                        "performance-now": "0.2.0",
-                        "qs": "6.4.0",
-                        "safe-buffer": "5.0.1",
-                        "stringstream": "0.0.5",
-                        "tough-cookie": "2.3.2",
-                        "tunnel-agent": "0.6.0",
-                        "uuid": "3.0.1"
+                        "aws-sign2": "~0.6.0",
+                        "aws4": "^1.2.1",
+                        "caseless": "~0.12.0",
+                        "combined-stream": "~1.0.5",
+                        "extend": "~3.0.0",
+                        "forever-agent": "~0.6.1",
+                        "form-data": "~2.1.1",
+                        "har-validator": "~4.2.1",
+                        "hawk": "~3.1.3",
+                        "http-signature": "~1.1.0",
+                        "is-typedarray": "~1.0.0",
+                        "isstream": "~0.1.2",
+                        "json-stringify-safe": "~5.0.1",
+                        "mime-types": "~2.1.7",
+                        "oauth-sign": "~0.8.1",
+                        "performance-now": "^0.2.0",
+                        "qs": "~6.4.0",
+                        "safe-buffer": "^5.0.1",
+                        "stringstream": "~0.0.4",
+                        "tough-cookie": "~2.3.0",
+                        "tunnel-agent": "^0.6.0",
+                        "uuid": "^3.0.0"
                     }
                 },
                 "rimraf": {
@@ -4976,7 +5205,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "glob": "7.1.2"
+                        "glob": "^7.0.5"
                     }
                 },
                 "safe-buffer": {
@@ -5007,7 +5236,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "hoek": "2.16.3"
+                        "hoek": "2.x.x"
                     }
                 },
                 "sshpk": {
@@ -5016,15 +5245,15 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "asn1": "0.2.3",
-                        "assert-plus": "1.0.0",
-                        "bcrypt-pbkdf": "1.0.1",
-                        "dashdash": "1.14.1",
-                        "ecc-jsbn": "0.1.1",
-                        "getpass": "0.1.7",
-                        "jodid25519": "1.0.2",
-                        "jsbn": "0.1.1",
-                        "tweetnacl": "0.14.5"
+                        "asn1": "~0.2.3",
+                        "assert-plus": "^1.0.0",
+                        "bcrypt-pbkdf": "^1.0.0",
+                        "dashdash": "^1.12.0",
+                        "ecc-jsbn": "~0.1.1",
+                        "getpass": "^0.1.1",
+                        "jodid25519": "^1.0.0",
+                        "jsbn": "~0.1.0",
+                        "tweetnacl": "~0.14.0"
                     },
                     "dependencies": {
                         "assert-plus": {
@@ -5040,9 +5269,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
                     }
                 },
                 "string_decoder": {
@@ -5050,7 +5279,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.0.1"
+                        "safe-buffer": "^5.0.1"
                     }
                 },
                 "stringstream": {
@@ -5064,7 +5293,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "2.1.1"
+                        "ansi-regex": "^2.0.0"
                     }
                 },
                 "strip-json-comments": {
@@ -5078,9 +5307,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "block-stream": "0.0.9",
-                        "fstream": "1.0.11",
-                        "inherits": "2.0.3"
+                        "block-stream": "*",
+                        "fstream": "^1.0.2",
+                        "inherits": "2"
                     }
                 },
                 "tar-pack": {
@@ -5089,14 +5318,14 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "debug": "2.6.8",
-                        "fstream": "1.0.11",
-                        "fstream-ignore": "1.0.5",
-                        "once": "1.4.0",
-                        "readable-stream": "2.2.9",
-                        "rimraf": "2.6.1",
-                        "tar": "2.2.1",
-                        "uid-number": "0.0.6"
+                        "debug": "^2.2.0",
+                        "fstream": "^1.0.10",
+                        "fstream-ignore": "^1.0.5",
+                        "once": "^1.3.3",
+                        "readable-stream": "^2.1.4",
+                        "rimraf": "^2.5.1",
+                        "tar": "^2.2.1",
+                        "uid-number": "^0.0.6"
                     }
                 },
                 "tough-cookie": {
@@ -5105,7 +5334,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "punycode": "1.4.1"
+                        "punycode": "^1.4.1"
                     }
                 },
                 "tunnel-agent": {
@@ -5114,7 +5343,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "safe-buffer": "5.0.1"
+                        "safe-buffer": "^5.0.1"
                     }
                 },
                 "tweetnacl": {
@@ -5155,7 +5384,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "string-width": "1.0.2"
+                        "string-width": "^1.0.2"
                     }
                 },
                 "wrappy": {
@@ -5171,10 +5400,10 @@
             "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "inherits": "2.0.3",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2"
+                "graceful-fs": "^4.1.2",
+                "inherits": "~2.0.0",
+                "mkdirp": ">=0.5 0",
+                "rimraf": "2"
             },
             "dependencies": {
                 "minimist": {
@@ -5200,14 +5429,14 @@
             "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
             "dev": true,
             "requires": {
-                "aproba": "1.2.0",
-                "console-control-strings": "1.1.0",
-                "has-unicode": "2.0.1",
-                "object-assign": "4.1.1",
-                "signal-exit": "3.0.2",
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "wide-align": "1.1.2"
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
             }
         },
         "gaze": {
@@ -5216,7 +5445,7 @@
             "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
             "dev": true,
             "requires": {
-                "globule": "0.1.0"
+                "globule": "~0.1.0"
             }
         },
         "generate-function": {
@@ -5231,7 +5460,7 @@
             "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
             "dev": true,
             "requires": {
-                "is-property": "1.0.2"
+                "is-property": "^1.0.0"
             }
         },
         "get-caller-file": {
@@ -5258,13 +5487,19 @@
             "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
             "dev": true
         },
+        "get-value": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+            "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+            "dev": true
+        },
         "getpass": {
             "version": "0.1.7",
             "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -5281,8 +5516,8 @@
             "integrity": "sha1-7pW+NxBv2HSKlvjR20uuqJ4b+oo=",
             "dev": true,
             "requires": {
-                "got": "6.7.1",
-                "is-plain-obj": "1.1.0"
+                "got": "^6.2.0",
+                "is-plain-obj": "^1.1.0"
             },
             "dependencies": {
                 "got": {
@@ -5291,17 +5526,17 @@
                     "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
                     "dev": true,
                     "requires": {
-                        "create-error-class": "3.0.2",
-                        "duplexer3": "0.1.4",
-                        "get-stream": "3.0.0",
-                        "is-redirect": "1.0.0",
-                        "is-retry-allowed": "1.1.0",
-                        "is-stream": "1.1.0",
-                        "lowercase-keys": "1.0.0",
-                        "safe-buffer": "5.1.1",
-                        "timed-out": "4.0.1",
-                        "unzip-response": "2.0.1",
-                        "url-parse-lax": "1.0.0"
+                        "create-error-class": "^3.0.0",
+                        "duplexer3": "^0.1.4",
+                        "get-stream": "^3.0.0",
+                        "is-redirect": "^1.0.0",
+                        "is-retry-allowed": "^1.0.0",
+                        "is-stream": "^1.0.0",
+                        "lowercase-keys": "^1.0.0",
+                        "safe-buffer": "^5.0.1",
+                        "timed-out": "^4.0.0",
+                        "unzip-response": "^2.0.1",
+                        "url-parse-lax": "^1.0.0"
                     }
                 },
                 "timed-out": {
@@ -5325,9 +5560,9 @@
             "dev": true,
             "requires": {
                 "follow-redirects": "0.0.7",
-                "https-proxy-agent": "1.0.0",
-                "mime": "1.6.0",
-                "netrc": "0.1.4"
+                "https-proxy-agent": "^1.0.0",
+                "mime": "^1.2.11",
+                "netrc": "^0.1.4"
             },
             "dependencies": {
                 "mime": {
@@ -5344,7 +5579,7 @@
             "integrity": "sha1-CnciGbMTB0NCnyRW0L3T21Xc57E=",
             "dev": true,
             "requires": {
-                "gh-got": "5.0.0"
+                "gh-got": "^5.0.0"
             }
         },
         "glob": {
@@ -5353,10 +5588,10 @@
             "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
             "dev": true,
             "requires": {
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "2.0.10",
-                "once": "1.3.3"
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^2.0.1",
+                "once": "^1.3.0"
             },
             "dependencies": {
                 "minimatch": {
@@ -5365,7 +5600,7 @@
                     "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
                     "dev": true,
                     "requires": {
-                        "brace-expansion": "1.1.8"
+                        "brace-expansion": "^1.0.0"
                     }
                 }
             }
@@ -5376,8 +5611,8 @@
             "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
             "dev": true,
             "requires": {
-                "glob-parent": "2.0.0",
-                "is-glob": "2.0.1"
+                "glob-parent": "^2.0.0",
+                "is-glob": "^2.0.0"
             }
         },
         "glob-parent": {
@@ -5386,7 +5621,7 @@
             "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
             "dev": true,
             "requires": {
-                "is-glob": "2.0.1"
+                "is-glob": "^2.0.0"
             }
         },
         "glob-stream": {
@@ -5395,12 +5630,12 @@
             "integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
             "dev": true,
             "requires": {
-                "glob": "4.5.3",
-                "glob2base": "0.0.12",
-                "minimatch": "2.0.10",
-                "ordered-read-streams": "0.1.0",
-                "through2": "0.6.5",
-                "unique-stream": "1.0.0"
+                "glob": "^4.3.1",
+                "glob2base": "^0.0.12",
+                "minimatch": "^2.0.1",
+                "ordered-read-streams": "^0.1.0",
+                "through2": "^0.6.1",
+                "unique-stream": "^1.0.0"
             },
             "dependencies": {
                 "isarray": {
@@ -5415,7 +5650,7 @@
                     "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
                     "dev": true,
                     "requires": {
-                        "brace-expansion": "1.1.8"
+                        "brace-expansion": "^1.0.0"
                     }
                 },
                 "readable-stream": {
@@ -5424,10 +5659,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -5442,8 +5677,8 @@
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "4.0.1"
+                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                        "xtend": ">=4.0.0 <4.1.0-0"
                     }
                 }
             }
@@ -5454,7 +5689,7 @@
             "integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=",
             "dev": true,
             "requires": {
-                "gaze": "0.5.2"
+                "gaze": "^0.5.1"
             }
         },
         "glob2base": {
@@ -5463,7 +5698,7 @@
             "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
             "dev": true,
             "requires": {
-                "find-index": "0.1.1"
+                "find-index": "^0.1.1"
             }
         },
         "global-dirs": {
@@ -5473,7 +5708,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "ini": "1.3.5"
+                "ini": "^1.3.4"
             }
         },
         "global-modules": {
@@ -5482,8 +5717,8 @@
             "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
             "dev": true,
             "requires": {
-                "global-prefix": "0.1.5",
-                "is-windows": "0.2.0"
+                "global-prefix": "^0.1.4",
+                "is-windows": "^0.2.0"
             }
         },
         "global-prefix": {
@@ -5492,10 +5727,10 @@
             "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
             "dev": true,
             "requires": {
-                "homedir-polyfill": "1.0.1",
-                "ini": "1.3.5",
-                "is-windows": "0.2.0",
-                "which": "1.3.0"
+                "homedir-polyfill": "^1.0.0",
+                "ini": "^1.3.4",
+                "is-windows": "^0.2.0",
+                "which": "^1.2.12"
             }
         },
         "globals": {
@@ -5510,11 +5745,11 @@
             "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
             "dev": true,
             "requires": {
-                "array-union": "1.0.2",
-                "glob": "7.1.2",
-                "object-assign": "4.1.1",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1"
+                "array-union": "^1.0.1",
+                "glob": "^7.0.3",
+                "object-assign": "^4.0.1",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
             },
             "dependencies": {
                 "glob": {
@@ -5523,12 +5758,12 @@
                     "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.3.3",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 }
             }
@@ -5539,9 +5774,9 @@
             "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
             "dev": true,
             "requires": {
-                "glob": "3.1.21",
-                "lodash": "1.0.2",
-                "minimatch": "0.2.14"
+                "glob": "~3.1.21",
+                "lodash": "~1.0.1",
+                "minimatch": "~0.2.11"
             },
             "dependencies": {
                 "glob": {
@@ -5550,9 +5785,9 @@
                     "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "1.2.3",
-                        "inherits": "1.0.2",
-                        "minimatch": "0.2.14"
+                        "graceful-fs": "~1.2.0",
+                        "inherits": "1",
+                        "minimatch": "~0.2.11"
                     }
                 },
                 "graceful-fs": {
@@ -5579,8 +5814,8 @@
                     "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
                     "dev": true,
                     "requires": {
-                        "lru-cache": "2.7.3",
-                        "sigmund": "1.0.1"
+                        "lru-cache": "2",
+                        "sigmund": "~1.0.0"
                     }
                 }
             }
@@ -5591,7 +5826,7 @@
             "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
             "dev": true,
             "requires": {
-                "sparkles": "1.0.0"
+                "sparkles": "^1.0.0"
             }
         },
         "got": {
@@ -5600,21 +5835,21 @@
             "integrity": "sha1-X4FjWmHkplifGAVp6k44FoClHzU=",
             "dev": true,
             "requires": {
-                "create-error-class": "3.0.2",
-                "duplexer2": "0.1.4",
-                "is-redirect": "1.0.0",
-                "is-retry-allowed": "1.1.0",
-                "is-stream": "1.1.0",
-                "lowercase-keys": "1.0.0",
-                "node-status-codes": "1.0.0",
-                "object-assign": "4.1.1",
-                "parse-json": "2.2.0",
-                "pinkie-promise": "2.0.1",
-                "read-all-stream": "3.1.0",
-                "readable-stream": "2.3.3",
-                "timed-out": "3.1.3",
-                "unzip-response": "1.0.2",
-                "url-parse-lax": "1.0.0"
+                "create-error-class": "^3.0.1",
+                "duplexer2": "^0.1.4",
+                "is-redirect": "^1.0.0",
+                "is-retry-allowed": "^1.0.0",
+                "is-stream": "^1.0.0",
+                "lowercase-keys": "^1.0.0",
+                "node-status-codes": "^1.0.0",
+                "object-assign": "^4.0.1",
+                "parse-json": "^2.1.0",
+                "pinkie-promise": "^2.0.0",
+                "read-all-stream": "^3.0.0",
+                "readable-stream": "^2.0.5",
+                "timed-out": "^3.0.0",
+                "unzip-response": "^1.0.2",
+                "url-parse-lax": "^1.0.0"
             },
             "dependencies": {
                 "duplexer2": {
@@ -5623,7 +5858,7 @@
                     "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "2.3.3"
+                        "readable-stream": "^2.0.2"
                     }
                 }
             }
@@ -5646,7 +5881,7 @@
             "integrity": "sha1-wWfSpTGcWg4JZO9qJbfC34mWyFw=",
             "dev": true,
             "requires": {
-                "lodash": "4.17.4"
+                "lodash": "^4.17.2"
             },
             "dependencies": {
                 "lodash": {
@@ -5669,19 +5904,19 @@
             "integrity": "sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=",
             "dev": true,
             "requires": {
-                "archy": "1.0.0",
-                "chalk": "1.1.3",
-                "deprecated": "0.0.1",
-                "gulp-util": "3.0.8",
-                "interpret": "1.1.0",
-                "liftoff": "2.3.0",
-                "minimist": "1.2.0",
-                "orchestrator": "0.3.8",
-                "pretty-hrtime": "1.0.3",
-                "semver": "4.3.6",
-                "tildify": "1.2.0",
-                "v8flags": "2.1.1",
-                "vinyl-fs": "0.3.14"
+                "archy": "^1.0.0",
+                "chalk": "^1.0.0",
+                "deprecated": "^0.0.1",
+                "gulp-util": "^3.0.0",
+                "interpret": "^1.0.0",
+                "liftoff": "^2.1.0",
+                "minimist": "^1.1.0",
+                "orchestrator": "^0.3.0",
+                "pretty-hrtime": "^1.0.0",
+                "semver": "^4.1.0",
+                "tildify": "^1.0.0",
+                "v8flags": "^2.0.2",
+                "vinyl-fs": "^0.3.0"
             },
             "dependencies": {
                 "semver": {
@@ -5698,11 +5933,11 @@
             "integrity": "sha1-dSMAUc0NFxND14O36bXREg7u+bA=",
             "dev": true,
             "requires": {
-                "autoprefixer": "6.7.7",
-                "gulp-util": "3.0.8",
-                "postcss": "5.2.18",
-                "through2": "2.0.3",
-                "vinyl-sourcemaps-apply": "0.2.1"
+                "autoprefixer": "^6.0.0",
+                "gulp-util": "^3.0.0",
+                "postcss": "^5.0.4",
+                "through2": "^2.0.0",
+                "vinyl-sourcemaps-apply": "^0.2.0"
             }
         },
         "gulp-bump": {
@@ -5711,11 +5946,11 @@
             "integrity": "sha512-syvQLax2xQo1EDFJxanUqX1rv+YkVB4/cx/THN+uInmSjMGezT1/6WYLdXqkBAMQUw2KlyB2melz0DzrHdwkLA==",
             "dev": true,
             "requires": {
-                "bump-regex": "2.8.0",
-                "plugin-error": "0.1.2",
-                "plugin-log": "0.1.0",
-                "semver": "5.4.1",
-                "through2": "2.0.3"
+                "bump-regex": "^2.8.0",
+                "plugin-error": "^0.1.2",
+                "plugin-log": "^0.1.0",
+                "semver": "^5.3.0",
+                "through2": "^2.0.1"
             }
         },
         "gulp-clean": {
@@ -5724,9 +5959,9 @@
             "integrity": "sha1-o0fUc6zqQBgvk1WHpFGUFnGSgQI=",
             "dev": true,
             "requires": {
-                "gulp-util": "2.2.20",
-                "rimraf": "2.6.2",
-                "through2": "0.4.2"
+                "gulp-util": "^2.2.14",
+                "rimraf": "^2.2.8",
+                "through2": "^0.4.2"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -5747,11 +5982,11 @@
                     "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "1.1.0",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "0.1.0",
-                        "strip-ansi": "0.3.0",
-                        "supports-color": "0.2.0"
+                        "ansi-styles": "^1.1.0",
+                        "escape-string-regexp": "^1.0.0",
+                        "has-ansi": "^0.1.0",
+                        "strip-ansi": "^0.3.0",
+                        "supports-color": "^0.2.0"
                     }
                 },
                 "dateformat": {
@@ -5760,8 +5995,8 @@
                     "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
                     "dev": true,
                     "requires": {
-                        "get-stdin": "4.0.1",
-                        "meow": "3.7.0"
+                        "get-stdin": "^4.0.1",
+                        "meow": "^3.3.0"
                     }
                 },
                 "gulp-util": {
@@ -5770,14 +6005,14 @@
                     "integrity": "sha1-1xRuVyiRC9jwR6awseVJvCLb1kw=",
                     "dev": true,
                     "requires": {
-                        "chalk": "0.5.1",
-                        "dateformat": "1.0.12",
-                        "lodash._reinterpolate": "2.4.1",
-                        "lodash.template": "2.4.1",
-                        "minimist": "0.2.0",
-                        "multipipe": "0.1.2",
-                        "through2": "0.5.1",
-                        "vinyl": "0.2.3"
+                        "chalk": "^0.5.0",
+                        "dateformat": "^1.0.7-1.2.3",
+                        "lodash._reinterpolate": "^2.4.1",
+                        "lodash.template": "^2.4.1",
+                        "minimist": "^0.2.0",
+                        "multipipe": "^0.1.0",
+                        "through2": "^0.5.0",
+                        "vinyl": "^0.2.1"
                     },
                     "dependencies": {
                         "through2": {
@@ -5786,8 +6021,8 @@
                             "integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac=",
                             "dev": true,
                             "requires": {
-                                "readable-stream": "1.0.34",
-                                "xtend": "3.0.0"
+                                "readable-stream": "~1.0.17",
+                                "xtend": "~3.0.0"
                             }
                         }
                     }
@@ -5798,7 +6033,7 @@
                     "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "0.2.1"
+                        "ansi-regex": "^0.2.0"
                     }
                 },
                 "isarray": {
@@ -5819,9 +6054,9 @@
                     "integrity": "sha1-LOEsXghNsKV92l5dHu659dF1o7Q=",
                     "dev": true,
                     "requires": {
-                        "lodash._escapehtmlchar": "2.4.1",
-                        "lodash._reunescapedhtml": "2.4.1",
-                        "lodash.keys": "2.4.1"
+                        "lodash._escapehtmlchar": "~2.4.1",
+                        "lodash._reunescapedhtml": "~2.4.1",
+                        "lodash.keys": "~2.4.1"
                     }
                 },
                 "lodash.keys": {
@@ -5830,9 +6065,9 @@
                     "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
                     "dev": true,
                     "requires": {
-                        "lodash._isnative": "2.4.1",
-                        "lodash._shimkeys": "2.4.1",
-                        "lodash.isobject": "2.4.1"
+                        "lodash._isnative": "~2.4.1",
+                        "lodash._shimkeys": "~2.4.1",
+                        "lodash.isobject": "~2.4.1"
                     }
                 },
                 "lodash.template": {
@@ -5841,13 +6076,13 @@
                     "integrity": "sha1-nmEQB+32KRKal0qzxIuBez4c8g0=",
                     "dev": true,
                     "requires": {
-                        "lodash._escapestringchar": "2.4.1",
-                        "lodash._reinterpolate": "2.4.1",
-                        "lodash.defaults": "2.4.1",
-                        "lodash.escape": "2.4.1",
-                        "lodash.keys": "2.4.1",
-                        "lodash.templatesettings": "2.4.1",
-                        "lodash.values": "2.4.1"
+                        "lodash._escapestringchar": "~2.4.1",
+                        "lodash._reinterpolate": "~2.4.1",
+                        "lodash.defaults": "~2.4.1",
+                        "lodash.escape": "~2.4.1",
+                        "lodash.keys": "~2.4.1",
+                        "lodash.templatesettings": "~2.4.1",
+                        "lodash.values": "~2.4.1"
                     }
                 },
                 "lodash.templatesettings": {
@@ -5856,8 +6091,8 @@
                     "integrity": "sha1-6nbHXRHrhtTb6JqDiTu4YZKaxpk=",
                     "dev": true,
                     "requires": {
-                        "lodash._reinterpolate": "2.4.1",
-                        "lodash.escape": "2.4.1"
+                        "lodash._reinterpolate": "~2.4.1",
+                        "lodash.escape": "~2.4.1"
                     }
                 },
                 "minimist": {
@@ -5872,10 +6107,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -5890,7 +6125,7 @@
                     "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "0.2.1"
+                        "ansi-regex": "^0.2.1"
                     }
                 },
                 "supports-color": {
@@ -5905,8 +6140,8 @@
                     "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "2.1.2"
+                        "readable-stream": "~1.0.17",
+                        "xtend": "~2.1.1"
                     },
                     "dependencies": {
                         "xtend": {
@@ -5915,7 +6150,7 @@
                             "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
                             "dev": true,
                             "requires": {
-                                "object-keys": "0.4.0"
+                                "object-keys": "~0.4.0"
                             }
                         }
                     }
@@ -5926,7 +6161,7 @@
                     "integrity": "sha1-vKk4IJWC7FpJrVOKAPofEl5RMlI=",
                     "dev": true,
                     "requires": {
-                        "clone-stats": "0.0.1"
+                        "clone-stats": "~0.0.1"
                     }
                 },
                 "xtend": {
@@ -5943,9 +6178,9 @@
             "integrity": "sha1-Yz0WyV2IUEYorQJmVmPO5aR5M1M=",
             "dev": true,
             "requires": {
-                "concat-with-sourcemaps": "1.0.4",
-                "through2": "2.0.3",
-                "vinyl": "2.1.0"
+                "concat-with-sourcemaps": "^1.0.0",
+                "through2": "^2.0.0",
+                "vinyl": "^2.0.0"
             },
             "dependencies": {
                 "clone": {
@@ -5972,12 +6207,12 @@
                     "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
                     "dev": true,
                     "requires": {
-                        "clone": "2.1.1",
-                        "clone-buffer": "1.0.0",
-                        "clone-stats": "1.0.0",
-                        "cloneable-readable": "1.0.0",
-                        "remove-trailing-separator": "1.1.0",
-                        "replace-ext": "1.0.0"
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
             }
@@ -5988,13 +6223,13 @@
             "integrity": "sha1-9Xb+UhHRB7qpQBUEJJv4eu0VVr0=",
             "dev": true,
             "requires": {
-                "clean-css": "3.4.28",
-                "filesize": "2.0.4",
-                "graceful-fs": "2.0.3",
-                "gulp-rename": "1.1.0",
-                "gulp-util": "2.2.20",
+                "clean-css": "^3.1.9",
+                "filesize": "~2.0.0",
+                "graceful-fs": "~2.0.0",
+                "gulp-rename": "~1.1.0",
+                "gulp-util": "~2.2.0",
                 "map-stream": "0.0.4",
-                "temp-write": "0.1.1"
+                "temp-write": "~0.1.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -6015,11 +6250,11 @@
                     "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "1.1.0",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "0.1.0",
-                        "strip-ansi": "0.3.0",
-                        "supports-color": "0.2.0"
+                        "ansi-styles": "^1.1.0",
+                        "escape-string-regexp": "^1.0.0",
+                        "has-ansi": "^0.1.0",
+                        "strip-ansi": "^0.3.0",
+                        "supports-color": "^0.2.0"
                     }
                 },
                 "dateformat": {
@@ -6028,8 +6263,8 @@
                     "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
                     "dev": true,
                     "requires": {
-                        "get-stdin": "4.0.1",
-                        "meow": "3.7.0"
+                        "get-stdin": "^4.0.1",
+                        "meow": "^3.3.0"
                     }
                 },
                 "graceful-fs": {
@@ -6044,7 +6279,7 @@
                     "integrity": "sha1-kwkKqvTThsB/IFOKaIjxXvunJ6E=",
                     "dev": true,
                     "requires": {
-                        "map-stream": "0.0.4"
+                        "map-stream": ">=0.0.4"
                     }
                 },
                 "gulp-util": {
@@ -6053,14 +6288,14 @@
                     "integrity": "sha1-1xRuVyiRC9jwR6awseVJvCLb1kw=",
                     "dev": true,
                     "requires": {
-                        "chalk": "0.5.1",
-                        "dateformat": "1.0.12",
-                        "lodash._reinterpolate": "2.4.1",
-                        "lodash.template": "2.4.1",
-                        "minimist": "0.2.0",
-                        "multipipe": "0.1.2",
-                        "through2": "0.5.1",
-                        "vinyl": "0.2.3"
+                        "chalk": "^0.5.0",
+                        "dateformat": "^1.0.7-1.2.3",
+                        "lodash._reinterpolate": "^2.4.1",
+                        "lodash.template": "^2.4.1",
+                        "minimist": "^0.2.0",
+                        "multipipe": "^0.1.0",
+                        "through2": "^0.5.0",
+                        "vinyl": "^0.2.1"
                     }
                 },
                 "has-ansi": {
@@ -6069,7 +6304,7 @@
                     "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "0.2.1"
+                        "ansi-regex": "^0.2.0"
                     }
                 },
                 "isarray": {
@@ -6090,9 +6325,9 @@
                     "integrity": "sha1-LOEsXghNsKV92l5dHu659dF1o7Q=",
                     "dev": true,
                     "requires": {
-                        "lodash._escapehtmlchar": "2.4.1",
-                        "lodash._reunescapedhtml": "2.4.1",
-                        "lodash.keys": "2.4.1"
+                        "lodash._escapehtmlchar": "~2.4.1",
+                        "lodash._reunescapedhtml": "~2.4.1",
+                        "lodash.keys": "~2.4.1"
                     }
                 },
                 "lodash.keys": {
@@ -6101,9 +6336,9 @@
                     "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
                     "dev": true,
                     "requires": {
-                        "lodash._isnative": "2.4.1",
-                        "lodash._shimkeys": "2.4.1",
-                        "lodash.isobject": "2.4.1"
+                        "lodash._isnative": "~2.4.1",
+                        "lodash._shimkeys": "~2.4.1",
+                        "lodash.isobject": "~2.4.1"
                     }
                 },
                 "lodash.template": {
@@ -6112,13 +6347,13 @@
                     "integrity": "sha1-nmEQB+32KRKal0qzxIuBez4c8g0=",
                     "dev": true,
                     "requires": {
-                        "lodash._escapestringchar": "2.4.1",
-                        "lodash._reinterpolate": "2.4.1",
-                        "lodash.defaults": "2.4.1",
-                        "lodash.escape": "2.4.1",
-                        "lodash.keys": "2.4.1",
-                        "lodash.templatesettings": "2.4.1",
-                        "lodash.values": "2.4.1"
+                        "lodash._escapestringchar": "~2.4.1",
+                        "lodash._reinterpolate": "~2.4.1",
+                        "lodash.defaults": "~2.4.1",
+                        "lodash.escape": "~2.4.1",
+                        "lodash.keys": "~2.4.1",
+                        "lodash.templatesettings": "~2.4.1",
+                        "lodash.values": "~2.4.1"
                     }
                 },
                 "lodash.templatesettings": {
@@ -6127,8 +6362,8 @@
                     "integrity": "sha1-6nbHXRHrhtTb6JqDiTu4YZKaxpk=",
                     "dev": true,
                     "requires": {
-                        "lodash._reinterpolate": "2.4.1",
-                        "lodash.escape": "2.4.1"
+                        "lodash._reinterpolate": "~2.4.1",
+                        "lodash.escape": "~2.4.1"
                     }
                 },
                 "minimist": {
@@ -6143,10 +6378,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -6161,7 +6396,7 @@
                     "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "0.2.1"
+                        "ansi-regex": "^0.2.1"
                     }
                 },
                 "supports-color": {
@@ -6176,8 +6411,8 @@
                     "integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "3.0.0"
+                        "readable-stream": "~1.0.17",
+                        "xtend": "~3.0.0"
                     }
                 },
                 "vinyl": {
@@ -6186,7 +6421,7 @@
                     "integrity": "sha1-vKk4IJWC7FpJrVOKAPofEl5RMlI=",
                     "dev": true,
                     "requires": {
-                        "clone-stats": "0.0.1"
+                        "clone-stats": "~0.0.1"
                     }
                 },
                 "xtend": {
@@ -6203,9 +6438,9 @@
             "integrity": "sha1-pJe351cwBQQcqivIt92jyARE1ik=",
             "dev": true,
             "requires": {
-                "gulp-match": "1.0.3",
-                "ternary-stream": "2.0.1",
-                "through2": "2.0.3"
+                "gulp-match": "^1.0.3",
+                "ternary-stream": "^2.0.1",
+                "through2": "^2.0.1"
             }
         },
         "gulp-load-plugins": {
@@ -6214,13 +6449,13 @@
             "integrity": "sha1-TEGffldk2aDjMGG6uWGPgbc9QXE=",
             "dev": true,
             "requires": {
-                "array-unique": "0.2.1",
-                "fancy-log": "1.3.0",
-                "findup-sync": "0.4.3",
-                "gulplog": "1.0.0",
-                "has-gulplog": "0.1.0",
-                "micromatch": "2.3.11",
-                "resolve": "1.5.0"
+                "array-unique": "^0.2.1",
+                "fancy-log": "^1.2.0",
+                "findup-sync": "^0.4.0",
+                "gulplog": "^1.0.0",
+                "has-gulplog": "^0.1.0",
+                "micromatch": "^2.3.8",
+                "resolve": "^1.1.7"
             }
         },
         "gulp-match": {
@@ -6229,7 +6464,7 @@
             "integrity": "sha1-kcfA1/Kb7NZgbVfYCn+Hdqh6uo4=",
             "dev": true,
             "requires": {
-                "minimatch": "3.0.4"
+                "minimatch": "^3.0.3"
             }
         },
         "gulp-rename": {
@@ -6244,11 +6479,11 @@
             "integrity": "sha1-grerkP6QLNw0wE8YDZLyw0kC3VI=",
             "dev": true,
             "requires": {
-                "gulp-util": "3.0.8",
-                "lodash.clonedeep": "4.5.0",
-                "node-sass": "3.13.1",
-                "through2": "2.0.3",
-                "vinyl-sourcemaps-apply": "0.2.1"
+                "gulp-util": "^3.0",
+                "lodash.clonedeep": "^4.3.2",
+                "node-sass": "^3.4.2",
+                "through2": "^2.0.0",
+                "vinyl-sourcemaps-apply": "^0.2.0"
             }
         },
         "gulp-sequence": {
@@ -6257,8 +6492,8 @@
             "integrity": "sha1-44jWQxEEbgVUevQwNTUtlJVQHFA=",
             "dev": true,
             "requires": {
-                "gulp-util": "3.0.8",
-                "thunks": "4.9.0"
+                "gulp-util": ">=3.0.0",
+                "thunks": "^4.5.1"
             }
         },
         "gulp-sourcemaps": {
@@ -6267,11 +6502,11 @@
             "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
             "dev": true,
             "requires": {
-                "convert-source-map": "1.5.1",
-                "graceful-fs": "4.1.11",
-                "strip-bom": "2.0.0",
-                "through2": "2.0.3",
-                "vinyl": "1.2.0"
+                "convert-source-map": "^1.1.1",
+                "graceful-fs": "^4.1.2",
+                "strip-bom": "^2.0.0",
+                "through2": "^2.0.0",
+                "vinyl": "^1.0.0"
             },
             "dependencies": {
                 "vinyl": {
@@ -6280,8 +6515,8 @@
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.3",
-                        "clone-stats": "0.0.1",
+                        "clone": "^1.0.0",
+                        "clone-stats": "^0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
@@ -6293,8 +6528,8 @@
             "integrity": "sha1-eAiX53rhcjJnWUsxHjSPDp3DYoA=",
             "dev": true,
             "requires": {
-                "gulp-util": "3.0.8",
-                "through2": "2.0.3"
+                "gulp-util": "^3.0.6",
+                "through2": "^2.0.0"
             }
         },
         "gulp-util": {
@@ -6303,24 +6538,24 @@
             "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
             "dev": true,
             "requires": {
-                "array-differ": "1.0.0",
-                "array-uniq": "1.0.3",
-                "beeper": "1.1.1",
-                "chalk": "1.1.3",
-                "dateformat": "2.2.0",
-                "fancy-log": "1.3.0",
-                "gulplog": "1.0.0",
-                "has-gulplog": "0.1.0",
-                "lodash._reescape": "3.0.0",
-                "lodash._reevaluate": "3.0.0",
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.template": "3.6.2",
-                "minimist": "1.2.0",
-                "multipipe": "0.1.2",
-                "object-assign": "3.0.0",
+                "array-differ": "^1.0.0",
+                "array-uniq": "^1.0.2",
+                "beeper": "^1.0.0",
+                "chalk": "^1.0.0",
+                "dateformat": "^2.0.0",
+                "fancy-log": "^1.1.0",
+                "gulplog": "^1.0.0",
+                "has-gulplog": "^0.1.0",
+                "lodash._reescape": "^3.0.0",
+                "lodash._reevaluate": "^3.0.0",
+                "lodash._reinterpolate": "^3.0.0",
+                "lodash.template": "^3.0.0",
+                "minimist": "^1.1.0",
+                "multipipe": "^0.1.2",
+                "object-assign": "^3.0.0",
                 "replace-ext": "0.0.1",
-                "through2": "2.0.3",
-                "vinyl": "0.5.3"
+                "through2": "^2.0.0",
+                "vinyl": "^0.5.0"
             },
             "dependencies": {
                 "object-assign": {
@@ -6337,7 +6572,7 @@
             "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
             "dev": true,
             "requires": {
-                "glogg": "1.0.0"
+                "glogg": "^1.0.0"
             }
         },
         "gunzip-maybe": {
@@ -6346,12 +6581,12 @@
             "integrity": "sha512-qtutIKMthNJJgeHQS7kZ9FqDq59/Wn0G2HYCRNjpup7yKfVI6/eqwpmroyZGFoCYaG+sW6psNVb4zoLADHpp2g==",
             "dev": true,
             "requires": {
-                "browserify-zlib": "0.1.4",
-                "is-deflate": "1.0.0",
-                "is-gzip": "1.0.0",
-                "peek-stream": "1.1.2",
-                "pumpify": "1.3.5",
-                "through2": "2.0.3"
+                "browserify-zlib": "^0.1.4",
+                "is-deflate": "^1.0.0",
+                "is-gzip": "^1.0.0",
+                "peek-stream": "^1.1.0",
+                "pumpify": "^1.3.3",
+                "through2": "^2.0.3"
             }
         },
         "handle-thing": {
@@ -6372,8 +6607,8 @@
             "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
             "dev": true,
             "requires": {
-                "ajv": "4.11.8",
-                "har-schema": "1.0.5"
+                "ajv": "^4.9.1",
+                "har-schema": "^1.0.5"
             }
         },
         "has-ansi": {
@@ -6382,7 +6617,7 @@
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "dev": true,
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
         },
         "has-binary": {
@@ -6443,7 +6678,7 @@
             "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
             "dev": true,
             "requires": {
-                "sparkles": "1.0.0"
+                "sparkles": "^1.0.0"
             }
         },
         "has-unicode": {
@@ -6452,16 +6687,76 @@
             "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
             "dev": true
         },
+        "has-value": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+            "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+            "dev": true,
+            "requires": {
+                "get-value": "^2.0.6",
+                "has-values": "^1.0.0",
+                "isobject": "^3.0.0"
+            },
+            "dependencies": {
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
+                }
+            }
+        },
+        "has-values": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+            "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+            "dev": true,
+            "requires": {
+                "is-number": "^3.0.0",
+                "kind-of": "^4.0.0"
+            },
+            "dependencies": {
+                "is-number": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^3.0.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true,
+                            "requires": {
+                                "is-buffer": "^1.1.5"
+                            }
+                        }
+                    }
+                },
+                "kind-of": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+                    "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
+        },
         "hawk": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
             "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
             "dev": true,
             "requires": {
-                "boom": "2.10.1",
-                "cryptiles": "2.0.5",
-                "hoek": "2.16.3",
-                "sntp": "1.0.9"
+                "boom": "2.x.x",
+                "cryptiles": "2.x.x",
+                "hoek": "2.x.x",
+                "sntp": "1.x.x"
             }
         },
         "he": {
@@ -6482,8 +6777,8 @@
             "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
             "dev": true,
             "requires": {
-                "os-homedir": "1.0.2",
-                "os-tmpdir": "1.0.2"
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.1"
             }
         },
         "homedir-polyfill": {
@@ -6492,7 +6787,7 @@
             "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
             "dev": true,
             "requires": {
-                "parse-passwd": "1.0.0"
+                "parse-passwd": "^1.0.0"
             }
         },
         "hosted-git-info": {
@@ -6507,10 +6802,10 @@
             "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "obuf": "1.1.1",
-                "readable-stream": "2.3.3",
-                "wbuf": "1.7.2"
+                "inherits": "^2.0.1",
+                "obuf": "^1.0.0",
+                "readable-stream": "^2.0.1",
+                "wbuf": "^1.1.0"
             }
         },
         "html-minifier": {
@@ -6519,14 +6814,14 @@
             "integrity": "sha512-GISXn6oKDo7+gVpKOgZJTbHMCUI2TSGfpg/8jgencWhWJsvEmsvp3M8emX7QocsXsYznWloLib3OeSfeyb/ewg==",
             "dev": true,
             "requires": {
-                "camel-case": "3.0.0",
-                "clean-css": "4.1.9",
-                "commander": "2.12.2",
-                "he": "1.1.1",
-                "ncname": "1.0.0",
-                "param-case": "2.1.1",
-                "relateurl": "0.2.7",
-                "uglify-js": "3.2.0"
+                "camel-case": "3.0.x",
+                "clean-css": "4.1.x",
+                "commander": "2.12.x",
+                "he": "1.1.x",
+                "ncname": "1.0.x",
+                "param-case": "2.1.x",
+                "relateurl": "0.2.x",
+                "uglify-js": "3.2.x"
             },
             "dependencies": {
                 "clean-css": {
@@ -6535,7 +6830,7 @@
                     "integrity": "sha1-Nc7ornaHpJuYA09w3gDE7dOCYwE=",
                     "dev": true,
                     "requires": {
-                        "source-map": "0.5.7"
+                        "source-map": "0.5.x"
                     }
                 }
             }
@@ -6554,7 +6849,7 @@
             "requires": {
                 "inherits": "2.0.3",
                 "setprototypeof": "1.0.2",
-                "statuses": "1.3.1"
+                "statuses": ">= 1.3.1 < 2"
             }
         },
         "http-proxy": {
@@ -6563,8 +6858,8 @@
             "integrity": "sha1-ZC/cr/5S00SNK9o7AHnpQJBk2jE=",
             "dev": true,
             "requires": {
-                "eventemitter3": "1.2.0",
-                "requires-port": "1.0.0"
+                "eventemitter3": "1.x.x",
+                "requires-port": "1.x.x"
             }
         },
         "http-proxy-middleware": {
@@ -6573,10 +6868,10 @@
             "integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
             "dev": true,
             "requires": {
-                "http-proxy": "1.16.2",
-                "is-glob": "3.1.0",
-                "lodash": "4.17.4",
-                "micromatch": "2.3.11"
+                "http-proxy": "^1.16.2",
+                "is-glob": "^3.1.0",
+                "lodash": "^4.17.2",
+                "micromatch": "^2.3.11"
             },
             "dependencies": {
                 "http-proxy": {
@@ -6585,8 +6880,8 @@
                     "integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
                     "dev": true,
                     "requires": {
-                        "eventemitter3": "1.2.0",
-                        "requires-port": "1.0.0"
+                        "eventemitter3": "1.x.x",
+                        "requires-port": "1.x.x"
                     }
                 },
                 "is-extglob": {
@@ -6601,7 +6896,7 @@
                     "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "2.1.1"
+                        "is-extglob": "^2.1.0"
                     }
                 },
                 "lodash": {
@@ -6618,9 +6913,9 @@
             "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
             "dev": true,
             "requires": {
-                "assert-plus": "0.2.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.13.1"
+                "assert-plus": "^0.2.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
             }
         },
         "https-proxy-agent": {
@@ -6629,9 +6924,9 @@
             "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
             "dev": true,
             "requires": {
-                "agent-base": "2.1.1",
-                "debug": "2.2.0",
-                "extend": "3.0.1"
+                "agent-base": "2",
+                "debug": "2",
+                "extend": "3"
             }
         },
         "iconv-lite": {
@@ -6671,7 +6966,7 @@
             "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
             "dev": true,
             "requires": {
-                "repeating": "2.0.1"
+                "repeating": "^2.0.0"
             }
         },
         "indexof": {
@@ -6686,8 +6981,8 @@
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "dev": true,
             "requires": {
-                "once": "1.3.3",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
             }
         },
         "inherits": {
@@ -6708,20 +7003,20 @@
             "integrity": "sha1-TexvMvN+97sLLtPx0aXD9UUHSRg=",
             "dev": true,
             "requires": {
-                "ansi-escapes": "1.4.0",
-                "chalk": "1.1.3",
-                "cli-cursor": "1.0.2",
-                "cli-width": "2.2.0",
-                "external-editor": "1.1.1",
-                "figures": "1.7.0",
-                "lodash": "4.17.4",
+                "ansi-escapes": "^1.1.0",
+                "chalk": "^1.0.0",
+                "cli-cursor": "^1.0.1",
+                "cli-width": "^2.0.0",
+                "external-editor": "^1.1.0",
+                "figures": "^1.3.5",
+                "lodash": "^4.3.0",
                 "mute-stream": "0.0.6",
-                "pinkie-promise": "2.0.1",
-                "run-async": "2.3.0",
-                "rx": "4.1.0",
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "through": "2.3.8"
+                "pinkie-promise": "^2.0.0",
+                "run-async": "^2.2.0",
+                "rx": "^4.1.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.0",
+                "through": "^2.3.6"
             },
             "dependencies": {
                 "lodash": {
@@ -6750,7 +7045,7 @@
             "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
             "dev": true,
             "requires": {
-                "loose-envify": "1.3.1"
+                "loose-envify": "^1.0.0"
             }
         },
         "invert-kv": {
@@ -6766,13 +7061,30 @@
             "dev": true
         },
         "is-absolute": {
-            "version": "0.2.6",
-            "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
-            "integrity": "sha1-IN5p89uULvLYe5wto28XIjWxtes=",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
+            "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
             "dev": true,
             "requires": {
-                "is-relative": "0.2.1",
-                "is-windows": "0.2.0"
+                "is-relative": "^1.0.0",
+                "is-windows": "^1.0.1"
+            },
+            "dependencies": {
+                "is-windows": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+                    "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+                    "dev": true
+                }
+            }
+        },
+        "is-accessor-descriptor": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+            "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+            "dev": true,
+            "requires": {
+                "kind-of": "^3.0.2"
             }
         },
         "is-arrayish": {
@@ -6787,7 +7099,7 @@
             "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
             "dev": true,
             "requires": {
-                "binary-extensions": "1.11.0"
+                "binary-extensions": "^1.0.0"
             }
         },
         "is-buffer": {
@@ -6802,7 +7114,16 @@
             "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
             "dev": true,
             "requires": {
-                "builtin-modules": "1.1.1"
+                "builtin-modules": "^1.0.0"
+            }
+        },
+        "is-data-descriptor": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+            "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+            "dev": true,
+            "requires": {
+                "kind-of": "^3.0.2"
             }
         },
         "is-deflate": {
@@ -6810,6 +7131,25 @@
             "resolved": "https://registry.npmjs.org/is-deflate/-/is-deflate-1.0.0.tgz",
             "integrity": "sha1-yGKQHDwWH7CdrHzcfnhPgOmPLxQ=",
             "dev": true
+        },
+        "is-descriptor": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+            "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+            "dev": true,
+            "requires": {
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                    "dev": true
+                }
+            }
         },
         "is-dotfile": {
             "version": "1.0.3",
@@ -6823,7 +7163,7 @@
             "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
             "dev": true,
             "requires": {
-                "is-primitive": "2.0.0"
+                "is-primitive": "^2.0.0"
             }
         },
         "is-extendable": {
@@ -6844,7 +7184,7 @@
             "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
             "dev": true,
             "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
             }
         },
         "is-fullwidth-code-point": {
@@ -6853,7 +7193,7 @@
             "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
             "dev": true,
             "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
             }
         },
         "is-glob": {
@@ -6862,7 +7202,7 @@
             "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
             "dev": true,
             "requires": {
-                "is-extglob": "1.0.0"
+                "is-extglob": "^1.0.0"
             }
         },
         "is-gzip": {
@@ -6878,8 +7218,8 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "global-dirs": "0.1.1",
-                "is-path-inside": "1.0.0"
+                "global-dirs": "^0.1.0",
+                "is-path-inside": "^1.0.0"
             }
         },
         "is-my-json-valid": {
@@ -6888,10 +7228,10 @@
             "integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
             "dev": true,
             "requires": {
-                "generate-function": "2.0.0",
-                "generate-object-property": "1.2.0",
-                "jsonpointer": "4.0.1",
-                "xtend": "4.0.1"
+                "generate-function": "^2.0.0",
+                "generate-object-property": "^1.1.0",
+                "jsonpointer": "^4.0.0",
+                "xtend": "^4.0.0"
             }
         },
         "is-npm": {
@@ -6906,7 +7246,7 @@
             "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             }
         },
         "is-number-like": {
@@ -6915,7 +7255,7 @@
             "integrity": "sha512-6rZi3ezCyFcn5L71ywzz2bS5b2Igl1En3eTlZlvKjpz1n3IZLAYMbKYAIQgFmEu0GENg92ziU/faEOA/aixjbA==",
             "dev": true,
             "requires": {
-                "lodash.isfinite": "3.3.2"
+                "lodash.isfinite": "^3.3.2"
             }
         },
         "is-obj": {
@@ -6936,7 +7276,7 @@
             "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
             "dev": true,
             "requires": {
-                "is-path-inside": "1.0.0"
+                "is-path-inside": "^1.0.0"
             }
         },
         "is-path-inside": {
@@ -6945,7 +7285,7 @@
             "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
             "dev": true,
             "requires": {
-                "path-is-inside": "1.0.2"
+                "path-is-inside": "^1.0.1"
             }
         },
         "is-plain-obj": {
@@ -6960,7 +7300,7 @@
             "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.1"
             },
             "dependencies": {
                 "isobject": {
@@ -7002,12 +7342,12 @@
             "dev": true
         },
         "is-relative": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
-            "integrity": "sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU=",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
+            "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
             "dev": true,
             "requires": {
-                "is-unc-path": "0.1.2"
+                "is-unc-path": "^1.0.0"
             }
         },
         "is-retry-allowed": {
@@ -7029,12 +7369,12 @@
             "dev": true
         },
         "is-unc-path": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
-            "integrity": "sha1-arBTpyVzwQJQ/0FqOBTDUXivObk=",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
+            "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
             "dev": true,
             "requires": {
-                "unc-path-regex": "0.1.2"
+                "unc-path-regex": "^0.1.2"
             }
         },
         "is-utf8": {
@@ -7088,9 +7428,9 @@
             "integrity": "sha1-2+0qb1G+L3R1to+JRlgRFBt1iHQ=",
             "dev": true,
             "requires": {
-                "binaryextensions": "2.0.0",
-                "editions": "1.3.3",
-                "textextensions": "2.1.0"
+                "binaryextensions": "1 || 2",
+                "editions": "^1.1.1",
+                "textextensions": "1 || 2"
             }
         },
         "js-base64": {
@@ -7111,8 +7451,8 @@
             "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
             "dev": true,
             "requires": {
-                "argparse": "1.0.9",
-                "esprima": "4.0.0"
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
             }
         },
         "jsbn": {
@@ -7140,7 +7480,7 @@
             "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
             "dev": true,
             "requires": {
-                "jsonify": "0.0.0"
+                "jsonify": "~0.0.0"
             }
         },
         "json-stringify-safe": {
@@ -7167,7 +7507,7 @@
             "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11"
+                "graceful-fs": "^4.1.6"
             }
         },
         "jsonify": {
@@ -7214,7 +7554,7 @@
             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
             "dev": true,
             "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
             }
         },
         "latest-version": {
@@ -7223,7 +7563,7 @@
             "integrity": "sha1-VvjWE5YghHuAF/jx9NeOIRMkFos=",
             "dev": true,
             "requires": {
-                "package-json": "2.4.0"
+                "package-json": "^2.0.0"
             }
         },
         "launchpad": {
@@ -7233,12 +7573,12 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "async": "2.6.0",
-                "browserstack": "1.5.0",
-                "debug": "2.2.0",
-                "plist": "2.1.0",
-                "q": "1.5.1",
-                "underscore": "1.8.3"
+                "async": "^2.0.1",
+                "browserstack": "^1.2.0",
+                "debug": "^2.2.0",
+                "plist": "^2.0.1",
+                "q": "^1.4.1",
+                "underscore": "^1.8.3"
             },
             "dependencies": {
                 "async": {
@@ -7248,7 +7588,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "lodash": "4.17.4"
+                        "lodash": "^4.14.0"
                     }
                 },
                 "lodash": {
@@ -7279,7 +7619,7 @@
             "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.3"
+                "readable-stream": "^2.0.5"
             }
         },
         "lcid": {
@@ -7288,7 +7628,7 @@
             "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
             "dev": true,
             "requires": {
-                "invert-kv": "1.0.0"
+                "invert-kv": "^1.0.0"
             }
         },
         "levn": {
@@ -7297,25 +7637,418 @@
             "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
             "dev": true,
             "requires": {
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2"
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2"
             }
         },
         "liftoff": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.3.0.tgz",
-            "integrity": "sha1-qY8v9nGD2Lp8+soQVIvX/wVQs4U=",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.5.0.tgz",
+            "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
             "dev": true,
             "requires": {
-                "extend": "3.0.1",
-                "findup-sync": "0.4.3",
-                "fined": "1.1.0",
-                "flagged-respawn": "0.3.2",
-                "lodash.isplainobject": "4.0.6",
-                "lodash.isstring": "4.0.1",
-                "lodash.mapvalues": "4.6.0",
-                "rechoir": "0.6.2",
-                "resolve": "1.5.0"
+                "extend": "^3.0.0",
+                "findup-sync": "^2.0.0",
+                "fined": "^1.0.1",
+                "flagged-respawn": "^1.0.0",
+                "is-plain-object": "^2.0.4",
+                "object.map": "^1.0.0",
+                "rechoir": "^0.6.2",
+                "resolve": "^1.1.7"
+            },
+            "dependencies": {
+                "arr-diff": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+                    "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+                    "dev": true
+                },
+                "array-unique": {
+                    "version": "0.3.2",
+                    "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+                    "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+                    "dev": true
+                },
+                "braces": {
+                    "version": "2.3.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+                    "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+                    "dev": true,
+                    "requires": {
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "detect-file": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
+                    "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
+                    "dev": true
+                },
+                "expand-brackets": {
+                    "version": "2.1.4",
+                    "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+                    "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+                    "dev": true,
+                    "requires": {
+                        "debug": "^2.3.3",
+                        "define-property": "^0.2.5",
+                        "extend-shallow": "^2.0.1",
+                        "posix-character-classes": "^0.1.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "define-property": {
+                            "version": "0.2.5",
+                            "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                            "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                            "dev": true,
+                            "requires": {
+                                "is-descriptor": "^0.1.0"
+                            }
+                        },
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        },
+                        "is-accessor-descriptor": {
+                            "version": "0.1.6",
+                            "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+                            "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+                            "dev": true,
+                            "requires": {
+                                "kind-of": "^3.0.2"
+                            },
+                            "dependencies": {
+                                "kind-of": {
+                                    "version": "3.2.2",
+                                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                                    "dev": true,
+                                    "requires": {
+                                        "is-buffer": "^1.1.5"
+                                    }
+                                }
+                            }
+                        },
+                        "is-data-descriptor": {
+                            "version": "0.1.4",
+                            "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+                            "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+                            "dev": true,
+                            "requires": {
+                                "kind-of": "^3.0.2"
+                            },
+                            "dependencies": {
+                                "kind-of": {
+                                    "version": "3.2.2",
+                                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                                    "dev": true,
+                                    "requires": {
+                                        "is-buffer": "^1.1.5"
+                                    }
+                                }
+                            }
+                        },
+                        "is-descriptor": {
+                            "version": "0.1.6",
+                            "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+                            "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+                            "dev": true,
+                            "requires": {
+                                "is-accessor-descriptor": "^0.1.6",
+                                "is-data-descriptor": "^0.1.4",
+                                "kind-of": "^5.0.0"
+                            }
+                        },
+                        "kind-of": {
+                            "version": "5.1.0",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                            "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                            "dev": true
+                        }
+                    }
+                },
+                "expand-tilde": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+                    "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+                    "dev": true,
+                    "requires": {
+                        "homedir-polyfill": "^1.0.1"
+                    }
+                },
+                "extend-shallow": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+                    "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+                    "dev": true,
+                    "requires": {
+                        "assign-symbols": "^1.0.0",
+                        "is-extendable": "^1.0.1"
+                    },
+                    "dependencies": {
+                        "is-extendable": {
+                            "version": "1.0.1",
+                            "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+                            "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                            "dev": true,
+                            "requires": {
+                                "is-plain-object": "^2.0.4"
+                            }
+                        }
+                    }
+                },
+                "extglob": {
+                    "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+                    "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+                    "dev": true,
+                    "requires": {
+                        "array-unique": "^0.3.2",
+                        "define-property": "^1.0.0",
+                        "expand-brackets": "^2.1.4",
+                        "extend-shallow": "^2.0.1",
+                        "fragment-cache": "^0.2.1",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "define-property": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                            "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                            "dev": true,
+                            "requires": {
+                                "is-descriptor": "^1.0.0"
+                            }
+                        },
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "fill-range": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+                    "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+                    "dev": true,
+                    "requires": {
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "findup-sync": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
+                    "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
+                    "dev": true,
+                    "requires": {
+                        "detect-file": "^1.0.0",
+                        "is-glob": "^3.1.0",
+                        "micromatch": "^3.0.4",
+                        "resolve-dir": "^1.0.1"
+                    }
+                },
+                "global-modules": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+                    "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+                    "dev": true,
+                    "requires": {
+                        "global-prefix": "^1.0.1",
+                        "is-windows": "^1.0.1",
+                        "resolve-dir": "^1.0.0"
+                    }
+                },
+                "global-prefix": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+                    "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+                    "dev": true,
+                    "requires": {
+                        "expand-tilde": "^2.0.2",
+                        "homedir-polyfill": "^1.0.1",
+                        "ini": "^1.3.4",
+                        "is-windows": "^1.0.1",
+                        "which": "^1.2.14"
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
+                    }
+                },
+                "is-extglob": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+                    "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+                    "dev": true
+                },
+                "is-glob": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+                    "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "^2.1.0"
+                    }
+                },
+                "is-number": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^3.0.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true,
+                            "requires": {
+                                "is-buffer": "^1.1.5"
+                            }
+                        }
+                    }
+                },
+                "is-windows": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+                    "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+                    "dev": true
+                },
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
+                },
+                "kind-of": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+                    "dev": true
+                },
+                "micromatch": {
+                    "version": "3.1.10",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+                    "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+                    "dev": true,
+                    "requires": {
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                },
+                "resolve-dir": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+                    "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+                    "dev": true,
+                    "requires": {
+                        "expand-tilde": "^2.0.0",
+                        "global-modules": "^1.0.0"
+                    }
+                }
             }
         },
         "limiter": {
@@ -7330,11 +8063,11 @@
             "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "parse-json": "2.2.0",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1",
-                "strip-bom": "2.0.0"
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^2.2.0",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0",
+                "strip-bom": "^2.0.0"
             }
         },
         "localtunnel": {
@@ -7370,12 +8103,12 @@
                     "integrity": "sha1-GquWYOrnnYuPZ1vK7qtu40ws9pw=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "1.2.1",
-                        "cliui": "3.2.0",
-                        "decamelize": "1.2.0",
-                        "os-locale": "1.4.0",
-                        "window-size": "0.1.4",
-                        "y18n": "3.2.1"
+                        "camelcase": "^1.2.1",
+                        "cliui": "^3.0.3",
+                        "decamelize": "^1.0.0",
+                        "os-locale": "^1.4.0",
+                        "window-size": "^0.1.2",
+                        "y18n": "^3.2.0"
                     }
                 }
             }
@@ -7386,8 +8119,8 @@
             "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
             "dev": true,
             "requires": {
-                "p-locate": "2.0.0",
-                "path-exists": "3.0.0"
+                "p-locate": "^2.0.0",
+                "path-exists": "^3.0.0"
             },
             "dependencies": {
                 "path-exists": {
@@ -7410,8 +8143,8 @@
             "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
             "dev": true,
             "requires": {
-                "lodash._basecopy": "3.0.1",
-                "lodash.keys": "3.1.2"
+                "lodash._basecopy": "^3.0.0",
+                "lodash.keys": "^3.0.0"
             }
         },
         "lodash._basecopy": {
@@ -7444,7 +8177,7 @@
             "integrity": "sha1-32fDu2t+jh6DGrSL+geVuSr+iZ0=",
             "dev": true,
             "requires": {
-                "lodash._htmlescapes": "2.4.1"
+                "lodash._htmlescapes": "~2.4.1"
             }
         },
         "lodash._escapestringchar": {
@@ -7507,8 +8240,8 @@
             "integrity": "sha1-dHxPxAED6zu4oJduVx96JlnpO6c=",
             "dev": true,
             "requires": {
-                "lodash._htmlescapes": "2.4.1",
-                "lodash.keys": "2.4.1"
+                "lodash._htmlescapes": "~2.4.1",
+                "lodash.keys": "~2.4.1"
             },
             "dependencies": {
                 "lodash.keys": {
@@ -7517,9 +8250,9 @@
                     "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
                     "dev": true,
                     "requires": {
-                        "lodash._isnative": "2.4.1",
-                        "lodash._shimkeys": "2.4.1",
-                        "lodash.isobject": "2.4.1"
+                        "lodash._isnative": "~2.4.1",
+                        "lodash._shimkeys": "~2.4.1",
+                        "lodash.isobject": "~2.4.1"
                     }
                 }
             }
@@ -7536,7 +8269,7 @@
             "integrity": "sha1-bpzJZm/wgfC1psl4uD4kLmlJ0gM=",
             "dev": true,
             "requires": {
-                "lodash._objecttypes": "2.4.1"
+                "lodash._objecttypes": "~2.4.1"
             }
         },
         "lodash.assign": {
@@ -7557,9 +8290,9 @@
             "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
             "dev": true,
             "requires": {
-                "lodash._baseassign": "3.2.0",
-                "lodash._basecreate": "3.0.3",
-                "lodash._isiterateecall": "3.0.9"
+                "lodash._baseassign": "^3.0.0",
+                "lodash._basecreate": "^3.0.0",
+                "lodash._isiterateecall": "^3.0.0"
             }
         },
         "lodash.defaults": {
@@ -7568,8 +8301,8 @@
             "integrity": "sha1-p+iIXwXmiFEUS24SqPNngCa8TFQ=",
             "dev": true,
             "requires": {
-                "lodash._objecttypes": "2.4.1",
-                "lodash.keys": "2.4.1"
+                "lodash._objecttypes": "~2.4.1",
+                "lodash.keys": "~2.4.1"
             },
             "dependencies": {
                 "lodash.keys": {
@@ -7578,9 +8311,9 @@
                     "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
                     "dev": true,
                     "requires": {
-                        "lodash._isnative": "2.4.1",
-                        "lodash._shimkeys": "2.4.1",
-                        "lodash.isobject": "2.4.1"
+                        "lodash._isnative": "~2.4.1",
+                        "lodash._shimkeys": "~2.4.1",
+                        "lodash.isobject": "~2.4.1"
                     }
                 }
             }
@@ -7591,7 +8324,7 @@
             "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
             "dev": true,
             "requires": {
-                "lodash._root": "3.0.1"
+                "lodash._root": "^3.0.0"
             }
         },
         "lodash.isarguments": {
@@ -7624,7 +8357,7 @@
             "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
             "dev": true,
             "requires": {
-                "lodash._objecttypes": "2.4.1"
+                "lodash._objecttypes": "~2.4.1"
             }
         },
         "lodash.isplainobject": {
@@ -7633,28 +8366,16 @@
             "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
             "dev": true
         },
-        "lodash.isstring": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-            "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
-            "dev": true
-        },
         "lodash.keys": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
             "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
             "dev": true,
             "requires": {
-                "lodash._getnative": "3.9.1",
-                "lodash.isarguments": "3.1.0",
-                "lodash.isarray": "3.0.4"
+                "lodash._getnative": "^3.0.0",
+                "lodash.isarguments": "^3.0.0",
+                "lodash.isarray": "^3.0.0"
             }
-        },
-        "lodash.mapvalues": {
-            "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
-            "integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw=",
-            "dev": true
         },
         "lodash.restparam": {
             "version": "3.6.1",
@@ -7674,15 +8395,15 @@
             "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
             "dev": true,
             "requires": {
-                "lodash._basecopy": "3.0.1",
-                "lodash._basetostring": "3.0.1",
-                "lodash._basevalues": "3.0.0",
-                "lodash._isiterateecall": "3.0.9",
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.escape": "3.2.0",
-                "lodash.keys": "3.1.2",
-                "lodash.restparam": "3.6.1",
-                "lodash.templatesettings": "3.1.1"
+                "lodash._basecopy": "^3.0.0",
+                "lodash._basetostring": "^3.0.0",
+                "lodash._basevalues": "^3.0.0",
+                "lodash._isiterateecall": "^3.0.0",
+                "lodash._reinterpolate": "^3.0.0",
+                "lodash.escape": "^3.0.0",
+                "lodash.keys": "^3.0.0",
+                "lodash.restparam": "^3.0.0",
+                "lodash.templatesettings": "^3.0.0"
             }
         },
         "lodash.templatesettings": {
@@ -7691,8 +8412,8 @@
             "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
             "dev": true,
             "requires": {
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.escape": "3.2.0"
+                "lodash._reinterpolate": "^3.0.0",
+                "lodash.escape": "^3.0.0"
             }
         },
         "lodash.values": {
@@ -7701,7 +8422,7 @@
             "integrity": "sha1-q/UUQ2s8twUAFieXjLzzCxKA7qQ=",
             "dev": true,
             "requires": {
-                "lodash.keys": "2.4.1"
+                "lodash.keys": "~2.4.1"
             },
             "dependencies": {
                 "lodash.keys": {
@@ -7710,9 +8431,9 @@
                     "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
                     "dev": true,
                     "requires": {
-                        "lodash._isnative": "2.4.1",
-                        "lodash._shimkeys": "2.4.1",
-                        "lodash.isobject": "2.4.1"
+                        "lodash._isnative": "~2.4.1",
+                        "lodash._shimkeys": "~2.4.1",
+                        "lodash.isobject": "~2.4.1"
                     }
                 }
             }
@@ -7723,7 +8444,7 @@
             "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3"
+                "chalk": "^1.0.0"
             }
         },
         "lolex": {
@@ -7738,7 +8459,7 @@
             "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
             "dev": true,
             "requires": {
-                "js-tokens": "3.0.2"
+                "js-tokens": "^3.0.0"
             }
         },
         "loud-rejection": {
@@ -7747,8 +8468,8 @@
             "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
             "dev": true,
             "requires": {
-                "currently-unhandled": "0.4.1",
-                "signal-exit": "3.0.2"
+                "currently-unhandled": "^0.4.1",
+                "signal-exit": "^3.0.0"
             }
         },
         "lower-case": {
@@ -7776,7 +8497,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "pify": "3.0.0"
+                "pify": "^3.0.0"
             },
             "dependencies": {
                 "pify": {
@@ -7785,6 +8506,23 @@
                     "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
                     "dev": true,
                     "optional": true
+                }
+            }
+        },
+        "make-iterator": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
+            "integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
+            "dev": true,
+            "requires": {
+                "kind-of": "^6.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+                    "dev": true
                 }
             }
         },
@@ -7806,15 +8544,24 @@
             "integrity": "sha1-XsbekCE+9sey65Nn6a3o2k79tos=",
             "dev": true
         },
+        "map-visit": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+            "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+            "dev": true,
+            "requires": {
+                "object-visit": "^1.0.0"
+            }
+        },
         "md5": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
             "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
             "dev": true,
             "requires": {
-                "charenc": "0.0.2",
-                "crypt": "0.0.2",
-                "is-buffer": "1.1.6"
+                "charenc": "~0.0.1",
+                "crypt": "~0.0.1",
+                "is-buffer": "~1.1.1"
             }
         },
         "media-typer": {
@@ -7829,9 +8576,9 @@
             "integrity": "sha1-uK6NLj/Lb10/kWXBLUVRoGXZicw=",
             "dev": true,
             "requires": {
-                "through2": "2.0.3",
-                "vinyl": "1.2.0",
-                "vinyl-file": "2.0.0"
+                "through2": "^2.0.0",
+                "vinyl": "^1.1.0",
+                "vinyl-file": "^2.0.0"
             },
             "dependencies": {
                 "vinyl": {
@@ -7840,8 +8587,8 @@
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.3",
-                        "clone-stats": "0.0.1",
+                        "clone": "^1.0.0",
+                        "clone-stats": "^0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
@@ -7853,16 +8600,16 @@
             "integrity": "sha1-3Qpuryu4prN3QAZ6pUnrUwEFr58=",
             "dev": true,
             "requires": {
-                "commondir": "1.0.1",
-                "deep-extend": "0.4.2",
-                "ejs": "2.5.7",
-                "glob": "7.1.2",
-                "globby": "6.1.0",
-                "mkdirp": "0.5.1",
-                "multimatch": "2.1.0",
-                "rimraf": "2.6.2",
-                "through2": "2.0.3",
-                "vinyl": "2.1.0"
+                "commondir": "^1.0.1",
+                "deep-extend": "^0.4.0",
+                "ejs": "^2.3.1",
+                "glob": "^7.0.3",
+                "globby": "^6.1.0",
+                "mkdirp": "^0.5.0",
+                "multimatch": "^2.0.0",
+                "rimraf": "^2.2.8",
+                "through2": "^2.0.0",
+                "vinyl": "^2.0.1"
             },
             "dependencies": {
                 "clone": {
@@ -7883,12 +8630,12 @@
                     "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.3.3",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "minimist": {
@@ -7918,12 +8665,12 @@
                     "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
                     "dev": true,
                     "requires": {
-                        "clone": "2.1.1",
-                        "clone-buffer": "1.0.0",
-                        "clone-stats": "1.0.0",
-                        "cloneable-readable": "1.0.0",
-                        "remove-trailing-separator": "1.1.0",
-                        "replace-ext": "1.0.0"
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
             }
@@ -7934,16 +8681,16 @@
             "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
             "dev": true,
             "requires": {
-                "camelcase-keys": "2.1.0",
-                "decamelize": "1.2.0",
-                "loud-rejection": "1.6.0",
-                "map-obj": "1.0.1",
-                "minimist": "1.2.0",
-                "normalize-package-data": "2.4.0",
-                "object-assign": "4.1.1",
-                "read-pkg-up": "1.0.1",
-                "redent": "1.0.0",
-                "trim-newlines": "1.0.0"
+                "camelcase-keys": "^2.0.0",
+                "decamelize": "^1.1.2",
+                "loud-rejection": "^1.0.0",
+                "map-obj": "^1.0.1",
+                "minimist": "^1.1.3",
+                "normalize-package-data": "^2.3.4",
+                "object-assign": "^4.0.1",
+                "read-pkg-up": "^1.0.1",
+                "redent": "^1.0.0",
+                "trim-newlines": "^1.0.0"
             }
         },
         "merge-descriptors": {
@@ -7958,7 +8705,7 @@
             "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.3"
+                "readable-stream": "^2.0.1"
             }
         },
         "methods": {
@@ -7973,19 +8720,19 @@
             "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
             "dev": true,
             "requires": {
-                "arr-diff": "2.0.0",
-                "array-unique": "0.2.1",
-                "braces": "1.8.5",
-                "expand-brackets": "0.1.5",
-                "extglob": "0.3.2",
-                "filename-regex": "2.0.1",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1",
-                "kind-of": "3.2.2",
-                "normalize-path": "2.1.1",
-                "object.omit": "2.0.1",
-                "parse-glob": "3.0.4",
-                "regex-cache": "0.4.4"
+                "arr-diff": "^2.0.0",
+                "array-unique": "^0.2.1",
+                "braces": "^1.8.2",
+                "expand-brackets": "^0.1.4",
+                "extglob": "^0.3.1",
+                "filename-regex": "^2.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.1",
+                "kind-of": "^3.0.2",
+                "normalize-path": "^2.0.1",
+                "object.omit": "^2.0.0",
+                "parse-glob": "^3.0.4",
+                "regex-cache": "^0.4.2"
             }
         },
         "mime": {
@@ -8006,7 +8753,7 @@
             "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
             "dev": true,
             "requires": {
-                "mime-db": "1.30.0"
+                "mime-db": "~1.30.0"
             }
         },
         "minimalistic-assert": {
@@ -8021,7 +8768,7 @@
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "dev": true,
             "requires": {
-                "brace-expansion": "1.1.8"
+                "brace-expansion": "^1.1.7"
             }
         },
         "minimatch-all": {
@@ -8030,7 +8777,7 @@
             "integrity": "sha1-QMSWonouEo0Zv3WOdrsBoMcUV4c=",
             "dev": true,
             "requires": {
-                "minimatch": "3.0.4"
+                "minimatch": "^3.0.2"
             }
         },
         "minimist": {
@@ -8038,6 +8785,27 @@
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
             "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
             "dev": true
+        },
+        "mixin-deep": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+            "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+            "dev": true,
+            "requires": {
+                "for-in": "^1.0.2",
+                "is-extendable": "^1.0.1"
+            },
+            "dependencies": {
+                "is-extendable": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+                    "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                    "dev": true,
+                    "requires": {
+                        "is-plain-object": "^2.0.4"
+                    }
+                }
+            }
         },
         "mkdirp": {
             "version": "0.3.0",
@@ -8071,7 +8839,7 @@
                     "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
                     "dev": true,
                     "requires": {
-                        "graceful-readlink": "1.0.1"
+                        "graceful-readlink": ">= 1.0.0"
                     }
                 },
                 "debug": {
@@ -8089,12 +8857,12 @@
                     "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.3.3",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.2",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "minimist": {
@@ -8124,7 +8892,7 @@
                     "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -8141,14 +8909,14 @@
             "integrity": "sha1-CSsmcPaEb6SRSWXvyM+Uwg/sbNI=",
             "dev": true,
             "requires": {
-                "append-field": "0.1.0",
-                "busboy": "0.2.14",
-                "concat-stream": "1.6.0",
-                "mkdirp": "0.5.1",
-                "object-assign": "3.0.0",
-                "on-finished": "2.3.0",
-                "type-is": "1.6.15",
-                "xtend": "4.0.1"
+                "append-field": "^0.1.0",
+                "busboy": "^0.2.11",
+                "concat-stream": "^1.5.0",
+                "mkdirp": "^0.5.1",
+                "object-assign": "^3.0.0",
+                "on-finished": "^2.3.0",
+                "type-is": "^1.6.4",
+                "xtend": "^4.0.0"
             },
             "dependencies": {
                 "minimist": {
@@ -8180,10 +8948,10 @@
             "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
             "dev": true,
             "requires": {
-                "array-differ": "1.0.0",
-                "array-union": "1.0.2",
-                "arrify": "1.0.1",
-                "minimatch": "3.0.4"
+                "array-differ": "^1.0.0",
+                "array-union": "^1.0.1",
+                "arrify": "^1.0.0",
+                "minimatch": "^3.0.0"
             }
         },
         "multipipe": {
@@ -8207,9 +8975,9 @@
             "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
             "dev": true,
             "requires": {
-                "any-promise": "1.3.0",
-                "object-assign": "4.1.1",
-                "thenify-all": "1.6.0"
+                "any-promise": "^1.0.0",
+                "object-assign": "^4.0.1",
+                "thenify-all": "^1.0.0"
             }
         },
         "nan": {
@@ -8218,6 +8986,70 @@
             "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
             "dev": true
         },
+        "nanomatch": {
+            "version": "1.2.13",
+            "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+            "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+            "dev": true,
+            "requires": {
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "fragment-cache": "^0.2.1",
+                "is-windows": "^1.0.2",
+                "kind-of": "^6.0.2",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+            },
+            "dependencies": {
+                "arr-diff": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+                    "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+                    "dev": true
+                },
+                "array-unique": {
+                    "version": "0.3.2",
+                    "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+                    "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+                    "dev": true
+                },
+                "extend-shallow": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+                    "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+                    "dev": true,
+                    "requires": {
+                        "assign-symbols": "^1.0.0",
+                        "is-extendable": "^1.0.1"
+                    }
+                },
+                "is-extendable": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+                    "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                    "dev": true,
+                    "requires": {
+                        "is-plain-object": "^2.0.4"
+                    }
+                },
+                "is-windows": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+                    "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+                    "dev": true
+                },
+                "kind-of": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+                    "dev": true
+                }
+            }
+        },
         "native-promise-only": {
             "version": "0.8.1",
             "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
@@ -8225,9 +9057,9 @@
             "dev": true
         },
         "natives": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz",
-            "integrity": "sha1-6f+EFBimsux6SV6TmYT3jxY+bjE=",
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.6.tgz",
+            "integrity": "sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==",
             "dev": true
         },
         "ncname": {
@@ -8236,7 +9068,7 @@
             "integrity": "sha1-W1etGLHKCShk72Kwse2BlPODtxw=",
             "dev": true,
             "requires": {
-                "xml-char-classes": "1.0.0"
+                "xml-char-classes": "^1.0.0"
             }
         },
         "negotiator": {
@@ -8257,7 +9089,7 @@
             "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
             "dev": true,
             "requires": {
-                "lower-case": "1.1.4"
+                "lower-case": "^1.1.1"
             }
         },
         "node-gyp": {
@@ -8266,19 +9098,19 @@
             "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
             "dev": true,
             "requires": {
-                "fstream": "1.0.11",
-                "glob": "7.1.2",
-                "graceful-fs": "4.1.11",
-                "minimatch": "3.0.4",
-                "mkdirp": "0.5.1",
-                "nopt": "3.0.6",
-                "npmlog": "4.1.2",
-                "osenv": "0.1.4",
-                "request": "2.81.0",
-                "rimraf": "2.6.2",
-                "semver": "5.3.0",
-                "tar": "2.2.1",
-                "which": "1.3.0"
+                "fstream": "^1.0.0",
+                "glob": "^7.0.3",
+                "graceful-fs": "^4.1.2",
+                "minimatch": "^3.0.2",
+                "mkdirp": "^0.5.0",
+                "nopt": "2 || 3",
+                "npmlog": "0 || 1 || 2 || 3 || 4",
+                "osenv": "0",
+                "request": "2",
+                "rimraf": "2",
+                "semver": "~5.3.0",
+                "tar": "^2.0.0",
+                "which": "1"
             },
             "dependencies": {
                 "glob": {
@@ -8287,12 +9119,12 @@
                     "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.3.3",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "minimist": {
@@ -8324,22 +9156,22 @@
             "integrity": "sha1-ckD7v/I5YwS0IjUn7TAgWJwAT8I=",
             "dev": true,
             "requires": {
-                "async-foreach": "0.1.3",
-                "chalk": "1.1.3",
-                "cross-spawn": "3.0.1",
-                "gaze": "1.1.2",
-                "get-stdin": "4.0.1",
-                "glob": "7.1.2",
-                "in-publish": "2.0.0",
-                "lodash.assign": "4.2.0",
-                "lodash.clonedeep": "4.5.0",
-                "meow": "3.7.0",
-                "mkdirp": "0.5.1",
-                "nan": "2.8.0",
-                "node-gyp": "3.6.2",
-                "npmlog": "4.1.2",
-                "request": "2.81.0",
-                "sass-graph": "2.2.4"
+                "async-foreach": "^0.1.3",
+                "chalk": "^1.1.1",
+                "cross-spawn": "^3.0.0",
+                "gaze": "^1.0.0",
+                "get-stdin": "^4.0.1",
+                "glob": "^7.0.3",
+                "in-publish": "^2.0.0",
+                "lodash.assign": "^4.2.0",
+                "lodash.clonedeep": "^4.3.2",
+                "meow": "^3.7.0",
+                "mkdirp": "^0.5.1",
+                "nan": "^2.3.2",
+                "node-gyp": "^3.3.1",
+                "npmlog": "^4.0.0",
+                "request": "^2.61.0",
+                "sass-graph": "^2.1.1"
             },
             "dependencies": {
                 "gaze": {
@@ -8348,7 +9180,7 @@
                     "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
                     "dev": true,
                     "requires": {
-                        "globule": "1.2.0"
+                        "globule": "^1.0.0"
                     }
                 },
                 "glob": {
@@ -8357,12 +9189,12 @@
                     "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.3.3",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "globule": {
@@ -8371,9 +9203,9 @@
                     "integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
                     "dev": true,
                     "requires": {
-                        "glob": "7.1.2",
-                        "lodash": "4.17.4",
-                        "minimatch": "3.0.4"
+                        "glob": "~7.1.1",
+                        "lodash": "~4.17.4",
+                        "minimatch": "~3.0.2"
                     }
                 },
                 "lodash": {
@@ -8405,7 +9237,7 @@
             "integrity": "sha1-TlI6oF1o2bN8frrPPxVoTmNbLy4=",
             "dev": true,
             "requires": {
-                "js-yaml": "3.10.0"
+                "js-yaml": "^3.2.7"
             }
         },
         "node-status-codes": {
@@ -8420,7 +9252,7 @@
             "integrity": "sha1-VyKxhPLfcycWEGSnkdLoQskWezQ=",
             "dev": true,
             "requires": {
-                "asap": "2.0.6"
+                "asap": "~2.0.3"
             }
         },
         "nomnom": {
@@ -8429,8 +9261,8 @@
             "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
             "dev": true,
             "requires": {
-                "chalk": "0.4.0",
-                "underscore": "1.6.0"
+                "chalk": "~0.4.0",
+                "underscore": "~1.6.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -8445,9 +9277,9 @@
                     "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "1.0.0",
-                        "has-color": "0.1.7",
-                        "strip-ansi": "0.1.1"
+                        "ansi-styles": "~1.0.0",
+                        "has-color": "~0.1.0",
+                        "strip-ansi": "~0.1.0"
                     }
                 },
                 "strip-ansi": {
@@ -8470,7 +9302,7 @@
             "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
             "dev": true,
             "requires": {
-                "abbrev": "1.1.1"
+                "abbrev": "1"
             }
         },
         "normalize-package-data": {
@@ -8479,10 +9311,10 @@
             "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
             "dev": true,
             "requires": {
-                "hosted-git-info": "2.5.0",
-                "is-builtin-module": "1.0.0",
-                "semver": "5.4.1",
-                "validate-npm-package-license": "3.0.1"
+                "hosted-git-info": "^2.1.4",
+                "is-builtin-module": "^1.0.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
             }
         },
         "normalize-path": {
@@ -8491,7 +9323,7 @@
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
             "dev": true,
             "requires": {
-                "remove-trailing-separator": "1.1.0"
+                "remove-trailing-separator": "^1.0.1"
             }
         },
         "normalize-range": {
@@ -8507,7 +9339,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "path-key": "2.0.1"
+                "path-key": "^2.0.0"
             }
         },
         "npmlog": {
@@ -8516,10 +9348,10 @@
             "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
             "dev": true,
             "requires": {
-                "are-we-there-yet": "1.1.4",
-                "console-control-strings": "1.1.0",
-                "gauge": "2.7.4",
-                "set-blocking": "2.0.0"
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
             }
         },
         "num2fraction": {
@@ -8552,6 +9384,28 @@
             "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE=",
             "dev": true
         },
+        "object-copy": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+            "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+            "dev": true,
+            "requires": {
+                "copy-descriptor": "^0.1.0",
+                "define-property": "^0.2.5",
+                "kind-of": "^3.0.3"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^0.1.0"
+                    }
+                }
+            }
+        },
         "object-keys": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
@@ -8564,16 +9418,33 @@
             "integrity": "sha1-D9mnT8X60a45aLWGvaXGMr1sBaU=",
             "dev": true
         },
+        "object-visit": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+            "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+            "dev": true,
+            "requires": {
+                "isobject": "^3.0.0"
+            },
+            "dependencies": {
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
+                }
+            }
+        },
         "object.defaults": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
             "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
             "dev": true,
             "requires": {
-                "array-each": "1.0.1",
-                "array-slice": "1.0.0",
-                "for-own": "1.0.0",
-                "isobject": "3.0.1"
+                "array-each": "^1.0.1",
+                "array-slice": "^1.0.0",
+                "for-own": "^1.0.0",
+                "isobject": "^3.0.0"
             },
             "dependencies": {
                 "for-own": {
@@ -8582,7 +9453,7 @@
                     "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
                     "dev": true,
                     "requires": {
-                        "for-in": "1.0.2"
+                        "for-in": "^1.0.1"
                     }
                 },
                 "isobject": {
@@ -8593,14 +9464,35 @@
                 }
             }
         },
+        "object.map": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/object.map/-/object.map-1.0.1.tgz",
+            "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
+            "dev": true,
+            "requires": {
+                "for-own": "^1.0.0",
+                "make-iterator": "^1.0.0"
+            },
+            "dependencies": {
+                "for-own": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+                    "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+                    "dev": true,
+                    "requires": {
+                        "for-in": "^1.0.1"
+                    }
+                }
+            }
+        },
         "object.omit": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
             "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
             "dev": true,
             "requires": {
-                "for-own": "0.1.5",
-                "is-extendable": "0.1.1"
+                "for-own": "^0.1.4",
+                "is-extendable": "^0.1.1"
             }
         },
         "object.pick": {
@@ -8609,7 +9501,7 @@
             "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.1"
             },
             "dependencies": {
                 "isobject": {
@@ -8647,7 +9539,7 @@
             "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
             "dev": true,
             "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
             }
         },
         "onetime": {
@@ -8668,8 +9560,8 @@
             "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
             "dev": true,
             "requires": {
-                "object-assign": "4.1.1",
-                "pinkie-promise": "2.0.1"
+                "object-assign": "^4.0.1",
+                "pinkie-promise": "^2.0.0"
             }
         },
         "optionator": {
@@ -8678,12 +9570,12 @@
             "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
             "dev": true,
             "requires": {
-                "deep-is": "0.1.3",
-                "fast-levenshtein": "2.0.6",
-                "levn": "0.3.0",
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2",
-                "wordwrap": "1.0.0"
+                "deep-is": "~0.1.3",
+                "fast-levenshtein": "~2.0.4",
+                "levn": "~0.3.0",
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2",
+                "wordwrap": "~1.0.0"
             }
         },
         "options": {
@@ -8698,9 +9590,9 @@
             "integrity": "sha1-FOfp4nZPcxX7rBhOUGx6pt+UrX4=",
             "dev": true,
             "requires": {
-                "end-of-stream": "0.1.5",
-                "sequencify": "0.0.7",
-                "stream-consume": "0.1.0"
+                "end-of-stream": "~0.1.5",
+                "sequencify": "~0.0.7",
+                "stream-consume": "~0.1.0"
             }
         },
         "ordered-read-streams": {
@@ -8721,7 +9613,7 @@
             "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
             "dev": true,
             "requires": {
-                "lcid": "1.0.0"
+                "lcid": "^1.0.0"
             }
         },
         "os-shim": {
@@ -8742,8 +9634,8 @@
             "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
             "dev": true,
             "requires": {
-                "os-homedir": "1.0.2",
-                "os-tmpdir": "1.0.2"
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
             }
         },
         "p-finally": {
@@ -8765,7 +9657,7 @@
             "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
             "dev": true,
             "requires": {
-                "p-limit": "1.1.0"
+                "p-limit": "^1.1.0"
             }
         },
         "p-map": {
@@ -8780,10 +9672,10 @@
             "integrity": "sha1-DRW9Z9HLvduyyiIv8u24a8sxqLs=",
             "dev": true,
             "requires": {
-                "got": "5.7.1",
-                "registry-auth-token": "3.3.1",
-                "registry-url": "3.1.0",
-                "semver": "5.4.1"
+                "got": "^5.0.0",
+                "registry-auth-token": "^3.0.1",
+                "registry-url": "^3.0.3",
+                "semver": "^5.1.0"
             }
         },
         "pako": {
@@ -8798,18 +9690,18 @@
             "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
             "dev": true,
             "requires": {
-                "no-case": "2.3.2"
+                "no-case": "^2.2.0"
             }
         },
         "parse-filepath": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.1.tgz",
-            "integrity": "sha1-FZ1hVdQ5BNFsEO9piRHaHpGWm3M=",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
+            "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
             "dev": true,
             "requires": {
-                "is-absolute": "0.2.6",
-                "map-cache": "0.2.2",
-                "path-root": "0.1.1"
+                "is-absolute": "^1.0.0",
+                "map-cache": "^0.2.0",
+                "path-root": "^0.1.1"
             }
         },
         "parse-glob": {
@@ -8818,10 +9710,10 @@
             "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
             "dev": true,
             "requires": {
-                "glob-base": "0.3.0",
-                "is-dotfile": "1.0.3",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1"
+                "glob-base": "^0.3.0",
+                "is-dotfile": "^1.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.0"
             }
         },
         "parse-json": {
@@ -8830,7 +9722,7 @@
             "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
             "dev": true,
             "requires": {
-                "error-ex": "1.3.1"
+                "error-ex": "^1.2.0"
             }
         },
         "parse-passwd": {
@@ -8851,7 +9743,7 @@
             "integrity": "sha1-q343WfIJ7OmUN5c/fQ8fZK4OZKs=",
             "dev": true,
             "requires": {
-                "better-assert": "1.0.2"
+                "better-assert": "~1.0.0"
             }
         },
         "parseqs": {
@@ -8860,7 +9752,7 @@
             "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
             "dev": true,
             "requires": {
-                "better-assert": "1.0.2"
+                "better-assert": "~1.0.0"
             }
         },
         "parseuri": {
@@ -8869,13 +9761,19 @@
             "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
             "dev": true,
             "requires": {
-                "better-assert": "1.0.2"
+                "better-assert": "~1.0.0"
             }
         },
         "parseurl": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
             "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
+            "dev": true
+        },
+        "pascalcase": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+            "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
             "dev": true
         },
         "path-dirname": {
@@ -8890,7 +9788,7 @@
             "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
             "dev": true,
             "requires": {
-                "pinkie-promise": "2.0.1"
+                "pinkie-promise": "^2.0.0"
             }
         },
         "path-is-absolute": {
@@ -8924,7 +9822,7 @@
             "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
             "dev": true,
             "requires": {
-                "path-root-regex": "0.1.2"
+                "path-root-regex": "^0.1.0"
             }
         },
         "path-root-regex": {
@@ -8956,9 +9854,9 @@
             "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1"
+                "graceful-fs": "^4.1.2",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
             }
         },
         "pathval": {
@@ -8973,8 +9871,8 @@
             "integrity": "sha1-l+t2NlvP2MieKH9VyLadTD6bzFI=",
             "dev": true,
             "requires": {
-                "duplexify": "3.5.1",
-                "through2": "2.0.3"
+                "duplexify": "^3.5.0",
+                "through2": "^2.0.3"
             }
         },
         "pem": {
@@ -8983,10 +9881,10 @@
             "integrity": "sha512-hT7GwvQL35+0iqgYUl8vn5I5pAVR0HcJas07TXL8bNaR4c5kAFRquk4ZqQk1F9YMcQOr6WjGdY5OnDC0RBnzig==",
             "dev": true,
             "requires": {
-                "md5": "2.2.1",
-                "os-tmpdir": "1.0.2",
-                "safe-buffer": "5.1.1",
-                "which": "1.3.0"
+                "md5": "^2.2.1",
+                "os-tmpdir": "^1.0.1",
+                "safe-buffer": "^5.1.1",
+                "which": "^1.2.4"
             }
         },
         "pend": {
@@ -9020,7 +9918,7 @@
             "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
             "dev": true,
             "requires": {
-                "pinkie": "2.0.4"
+                "pinkie": "^2.0.0"
             }
         },
         "plist": {
@@ -9032,7 +9930,7 @@
             "requires": {
                 "base64-js": "1.2.0",
                 "xmlbuilder": "8.2.2",
-                "xmldom": "0.1.27"
+                "xmldom": "0.1.x"
             }
         },
         "plugin-error": {
@@ -9041,11 +9939,11 @@
             "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
             "dev": true,
             "requires": {
-                "ansi-cyan": "0.1.1",
-                "ansi-red": "0.1.1",
-                "arr-diff": "1.1.0",
-                "arr-union": "2.1.0",
-                "extend-shallow": "1.1.4"
+                "ansi-cyan": "^0.1.1",
+                "ansi-red": "^0.1.1",
+                "arr-diff": "^1.0.1",
+                "arr-union": "^2.0.1",
+                "extend-shallow": "^1.1.2"
             },
             "dependencies": {
                 "arr-diff": {
@@ -9054,8 +9952,8 @@
                     "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0",
-                        "array-slice": "0.2.3"
+                        "arr-flatten": "^1.0.1",
+                        "array-slice": "^0.2.3"
                     }
                 },
                 "array-slice": {
@@ -9072,8 +9970,8 @@
             "integrity": "sha1-hgSc9qsQgzOYqTHzaJy67nteEzM=",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "dateformat": "1.0.12"
+                "chalk": "^1.1.1",
+                "dateformat": "^1.0.11"
             },
             "dependencies": {
                 "dateformat": {
@@ -9082,8 +9980,8 @@
                     "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
                     "dev": true,
                     "requires": {
-                        "get-stdin": "4.0.1",
-                        "meow": "3.7.0"
+                        "get-stdin": "^4.0.1",
+                        "meow": "^3.3.0"
                     }
                 }
             }
@@ -9094,7 +9992,7 @@
             "integrity": "sha1-2ODOzEz+bDTREJ4Onaqib+6NS3M=",
             "dev": true,
             "requires": {
-                "winston": "2.4.0"
+                "winston": "^2.2.0"
             }
         },
         "polymer-analyzer": {
@@ -9103,29 +10001,29 @@
             "integrity": "sha512-yD5FYQ8thX/2vHTaEgTtCs/NSG3ko4VlEb0IjM/PFsu03lHNHnpadC1NGwKyvI9vOjcFhnw4mDEVW0lbxLo8Eg==",
             "dev": true,
             "requires": {
-                "@types/chai-subset": "1.3.1",
-                "@types/chalk": "0.4.31",
-                "@types/clone": "0.1.30",
-                "@types/cssbeautify": "0.3.1",
-                "@types/doctrine": "0.0.1",
-                "@types/escodegen": "0.0.2",
-                "@types/estraverse": "0.0.6",
-                "@types/estree": "0.0.37",
-                "@types/node": "6.0.92",
-                "@types/parse5": "2.2.34",
-                "chalk": "1.1.3",
-                "clone": "2.1.1",
-                "cssbeautify": "0.3.1",
-                "doctrine": "2.0.2",
-                "dom5": "2.3.0",
-                "escodegen": "1.9.0",
-                "espree": "3.5.2",
-                "estraverse": "4.2.0",
-                "jsonschema": "1.2.0",
-                "parse5": "2.2.3",
-                "shady-css-parser": "0.1.0",
-                "stable": "0.1.6",
-                "strip-indent": "2.0.0"
+                "@types/chai-subset": "^1.3.0",
+                "@types/chalk": "^0.4.30",
+                "@types/clone": "^0.1.30",
+                "@types/cssbeautify": "^0.3.1",
+                "@types/doctrine": "^0.0.1",
+                "@types/escodegen": "^0.0.2",
+                "@types/estraverse": "^0.0.6",
+                "@types/estree": "^0.0.37",
+                "@types/node": "^6.0.0",
+                "@types/parse5": "^2.2.34",
+                "chalk": "^1.1.3",
+                "clone": "^2.0.0",
+                "cssbeautify": "^0.3.1",
+                "doctrine": "^2.0.0",
+                "dom5": "^2.1.0",
+                "escodegen": "^1.7.0",
+                "espree": "^3.1.7",
+                "estraverse": "^4.2.0",
+                "jsonschema": "^1.1.0",
+                "parse5": "^2.2.1",
+                "shady-css-parser": "^0.1.0",
+                "stable": "^0.1.6",
+                "strip-indent": "^2.0.0"
             },
             "dependencies": {
                 "@types/node": {
@@ -9155,21 +10053,21 @@
             "dev": true,
             "requires": {
                 "@types/mz": "0.0.31",
-                "@types/node": "6.0.92",
-                "@types/parse5": "2.2.34",
-                "@types/vinyl": "2.0.1",
+                "@types/node": "^6.0.77",
+                "@types/parse5": "^2.2.34",
+                "@types/vinyl": "^2.0.0",
                 "@types/vinyl-fs": "0.0.28",
-                "dom5": "2.3.0",
-                "multipipe": "1.0.2",
-                "mz": "2.7.0",
-                "parse5": "2.2.3",
-                "plylog": "0.5.0",
-                "polymer-analyzer": "2.7.0",
-                "polymer-bundler": "3.1.1",
-                "polymer-project-config": "3.5.0",
-                "sw-precache": "5.2.0",
-                "vinyl": "1.2.0",
-                "vinyl-fs": "2.4.4"
+                "dom5": "^2.3.0",
+                "multipipe": "^1.0.2",
+                "mz": "^2.6.0",
+                "parse5": "^2.2.3",
+                "plylog": "^0.5.0",
+                "polymer-analyzer": "^2.0.2",
+                "polymer-bundler": "^3.1.1",
+                "polymer-project-config": "^3.2.1",
+                "sw-precache": "^5.1.1",
+                "vinyl": "^1.2.0",
+                "vinyl-fs": "^2.4.4"
             },
             "dependencies": {
                 "@types/node": {
@@ -9184,7 +10082,7 @@
                     "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "2.3.3"
+                        "readable-stream": "^2.0.2"
                     }
                 },
                 "glob": {
@@ -9193,11 +10091,11 @@
                     "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                     "dev": true,
                     "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.3.3",
-                        "path-is-absolute": "1.0.1"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "glob-parent": {
@@ -9206,8 +10104,8 @@
                     "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
                     "dev": true,
                     "requires": {
-                        "is-glob": "3.1.0",
-                        "path-dirname": "1.0.2"
+                        "is-glob": "^3.1.0",
+                        "path-dirname": "^1.0.0"
                     }
                 },
                 "glob-stream": {
@@ -9216,14 +10114,14 @@
                     "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
                     "dev": true,
                     "requires": {
-                        "extend": "3.0.1",
-                        "glob": "5.0.15",
-                        "glob-parent": "3.1.0",
-                        "micromatch": "2.3.11",
-                        "ordered-read-streams": "0.3.0",
-                        "through2": "0.6.5",
-                        "to-absolute-glob": "0.1.1",
-                        "unique-stream": "2.2.1"
+                        "extend": "^3.0.0",
+                        "glob": "^5.0.3",
+                        "glob-parent": "^3.0.0",
+                        "micromatch": "^2.3.7",
+                        "ordered-read-streams": "^0.3.0",
+                        "through2": "^0.6.0",
+                        "to-absolute-glob": "^0.1.1",
+                        "unique-stream": "^2.0.2"
                     },
                     "dependencies": {
                         "readable-stream": {
@@ -9232,10 +10130,10 @@
                             "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                             "dev": true,
                             "requires": {
-                                "core-util-is": "1.0.2",
-                                "inherits": "2.0.3",
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.1",
                                 "isarray": "0.0.1",
-                                "string_decoder": "0.10.31"
+                                "string_decoder": "~0.10.x"
                             }
                         },
                         "through2": {
@@ -9244,8 +10142,8 @@
                             "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                             "dev": true,
                             "requires": {
-                                "readable-stream": "1.0.34",
-                                "xtend": "4.0.1"
+                                "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                                "xtend": ">=4.0.0 <4.1.0-0"
                             }
                         }
                     }
@@ -9262,7 +10160,7 @@
                     "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "2.1.1"
+                        "is-extglob": "^2.1.0"
                     }
                 },
                 "isarray": {
@@ -9292,8 +10190,8 @@
                     "integrity": "sha1-zBPv2DPJzamfIk+GhGG44aP9k50=",
                     "dev": true,
                     "requires": {
-                        "duplexer2": "0.1.4",
-                        "object-assign": "4.1.1"
+                        "duplexer2": "^0.1.2",
+                        "object-assign": "^4.1.0"
                     }
                 },
                 "ordered-read-streams": {
@@ -9302,8 +10200,8 @@
                     "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
                     "dev": true,
                     "requires": {
-                        "is-stream": "1.1.0",
-                        "readable-stream": "2.3.3"
+                        "is-stream": "^1.0.1",
+                        "readable-stream": "^2.0.1"
                     }
                 },
                 "plylog": {
@@ -9312,9 +10210,9 @@
                     "integrity": "sha1-yXbrodgNLdmRAF18EQ2vh0FUeI8=",
                     "dev": true,
                     "requires": {
-                        "@types/node": "4.2.23",
-                        "@types/winston": "2.3.7",
-                        "winston": "2.4.0"
+                        "@types/node": "^4.2.3",
+                        "@types/winston": "^2.2.0",
+                        "winston": "^2.2.0"
                     },
                     "dependencies": {
                         "@types/node": {
@@ -9337,8 +10235,8 @@
                     "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
                     "dev": true,
                     "requires": {
-                        "json-stable-stringify": "1.0.1",
-                        "through2-filter": "2.0.0"
+                        "json-stable-stringify": "^1.0.0",
+                        "through2-filter": "^2.0.0"
                     }
                 },
                 "vinyl": {
@@ -9347,8 +10245,8 @@
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.3",
-                        "clone-stats": "0.0.1",
+                        "clone": "^1.0.0",
+                        "clone-stats": "^0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 },
@@ -9358,23 +10256,23 @@
                     "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
                     "dev": true,
                     "requires": {
-                        "duplexify": "3.5.1",
-                        "glob-stream": "5.3.5",
-                        "graceful-fs": "4.1.11",
+                        "duplexify": "^3.2.0",
+                        "glob-stream": "^5.3.2",
+                        "graceful-fs": "^4.0.0",
                         "gulp-sourcemaps": "1.6.0",
-                        "is-valid-glob": "0.3.0",
-                        "lazystream": "1.0.0",
-                        "lodash.isequal": "4.5.0",
-                        "merge-stream": "1.0.1",
-                        "mkdirp": "0.5.1",
-                        "object-assign": "4.1.1",
-                        "readable-stream": "2.3.3",
-                        "strip-bom": "2.0.0",
-                        "strip-bom-stream": "1.0.0",
-                        "through2": "2.0.3",
-                        "through2-filter": "2.0.0",
-                        "vali-date": "1.0.0",
-                        "vinyl": "1.2.0"
+                        "is-valid-glob": "^0.3.0",
+                        "lazystream": "^1.0.0",
+                        "lodash.isequal": "^4.0.0",
+                        "merge-stream": "^1.0.0",
+                        "mkdirp": "^0.5.0",
+                        "object-assign": "^4.0.0",
+                        "readable-stream": "^2.0.4",
+                        "strip-bom": "^2.0.0",
+                        "strip-bom-stream": "^1.0.0",
+                        "through2": "^2.0.0",
+                        "through2-filter": "^2.0.0",
+                        "vali-date": "^1.0.0",
+                        "vinyl": "^1.0.0"
                     }
                 }
             }
@@ -9385,15 +10283,15 @@
             "integrity": "sha512-a/MItYr/rTRZ8Ymj5npmoAAm89RC5hRh4yz8bs22GyMn+NlE7HqJ4EzLrPkyRWlOyBhbhYFPx2Zot8PlaWXvmQ==",
             "dev": true,
             "requires": {
-                "clone": "2.1.1",
-                "command-line-args": "3.0.5",
-                "command-line-usage": "3.0.8",
-                "dom5": "2.3.0",
-                "espree": "3.5.2",
-                "mkdirp": "0.5.1",
-                "parse5": "2.2.3",
-                "polymer-analyzer": "2.7.0",
-                "source-map": "0.5.7"
+                "clone": "^2.1.0",
+                "command-line-args": "^3.0.1",
+                "command-line-usage": "^3.0.3",
+                "dom5": "^2.2.0",
+                "espree": "^3.4.0",
+                "mkdirp": "^0.5.1",
+                "parse5": "^2.2.2",
+                "polymer-analyzer": "^2.3.0",
+                "source-map": "^0.5.6"
             },
             "dependencies": {
                 "clone": {
@@ -9425,62 +10323,62 @@
             "integrity": "sha512-J2baUW9jknyB9wNIUo+TAaPzJvnRO4jrUx8Qn81zQCccLERlhmjTQukyjYLy+gXOejbLnIgdjhxWL5cQZwkwnQ==",
             "dev": true,
             "requires": {
-                "@types/babel-core": "6.25.3",
-                "@types/chalk": "0.4.31",
-                "@types/del": "3.0.0",
-                "@types/findup-sync": "0.3.29",
+                "@types/babel-core": "^6.7.14",
+                "@types/chalk": "^0.4.31",
+                "@types/del": "^3.0.0",
+                "@types/findup-sync": "^0.3.29",
                 "@types/gulp-if": "0.0.30",
-                "@types/html-minifier": "1.1.30",
+                "@types/html-minifier": "^1.1.30",
                 "@types/inquirer": "0.0.32",
-                "@types/merge-stream": "1.0.28",
-                "@types/mz": "0.0.31",
+                "@types/merge-stream": "^1.0.28",
+                "@types/mz": "^0.0.31",
                 "@types/request": "2.0.3",
                 "@types/resolve": "0.0.4",
-                "@types/rimraf": "0.0.28",
-                "@types/semver": "5.4.0",
-                "@types/temp": "0.8.31",
-                "@types/update-notifier": "1.0.2",
-                "@types/vinyl": "2.0.1",
+                "@types/rimraf": "^0.0.28",
+                "@types/semver": "^5.3.30",
+                "@types/temp": "^0.8.28",
+                "@types/update-notifier": "^1.0.0",
+                "@types/vinyl": "^2.0.0",
                 "@types/vinyl-fs": "0.0.28",
-                "@types/yeoman-generator": "1.0.4",
-                "babel-core": "6.26.0",
-                "babel-plugin-external-helpers": "6.22.0",
-                "babel-preset-es2015": "6.24.1",
+                "@types/yeoman-generator": "^1.0.0",
+                "babel-core": "^6.24.1",
+                "babel-plugin-external-helpers": "^6.22.0",
+                "babel-preset-es2015": "^6.18.0",
                 "babel-preset-minify": "0.2.0",
                 "bower": "1.8.2",
-                "bower-json": "0.8.1",
-                "bower-logger": "0.2.2",
-                "chalk": "1.1.3",
-                "command-line-args": "3.0.5",
-                "command-line-commands": "1.0.4",
-                "command-line-usage": "3.0.8",
-                "css-slam": "2.0.2",
-                "del": "3.0.0",
-                "findup-sync": "0.4.3",
-                "github": "7.3.2",
-                "gulp-if": "2.0.2",
-                "gunzip-maybe": "1.4.1",
-                "html-minifier": "3.5.7",
-                "inquirer": "1.2.3",
-                "merge-stream": "1.0.1",
-                "mz": "2.7.0",
-                "plylog": "0.4.0",
-                "polymer-analyzer": "2.7.0",
-                "polymer-build": "2.1.1",
-                "polymer-linter": "2.3.0",
-                "polymer-project-config": "3.5.0",
-                "polyserve": "0.23.0",
-                "request": "2.81.0",
-                "rimraf": "2.6.2",
-                "semver": "5.4.1",
-                "tar-fs": "1.16.0",
-                "temp": "0.8.3",
-                "update-notifier": "1.0.3",
-                "vinyl": "1.2.0",
-                "vinyl-fs": "2.4.4",
-                "web-component-tester": "6.4.1",
-                "yeoman-environment": "1.6.6",
-                "yeoman-generator": "1.1.1"
+                "bower-json": "^0.8.1",
+                "bower-logger": "^0.2.2",
+                "chalk": "^1.1.3",
+                "command-line-args": "^3.0.0",
+                "command-line-commands": "^1.0.3",
+                "command-line-usage": "^3.0.1",
+                "css-slam": "^2.0.2",
+                "del": "^3.0.0",
+                "findup-sync": "^0.4.2",
+                "github": "^7.2.1",
+                "gulp-if": "^2.0.0",
+                "gunzip-maybe": "^1.3.1",
+                "html-minifier": "^3.0.1",
+                "inquirer": "^1.0.2",
+                "merge-stream": "^1.0.1",
+                "mz": "^2.6.0",
+                "plylog": "^0.4.0",
+                "polymer-analyzer": "^2.3.0",
+                "polymer-build": "^2.1.0",
+                "polymer-linter": "^2.0.2",
+                "polymer-project-config": "^3.4.0",
+                "polyserve": "^0.23.0",
+                "request": "^2.72.0",
+                "rimraf": "^2.6.1",
+                "semver": "^5.3.0",
+                "tar-fs": "^1.12.0",
+                "temp": "^0.8.3",
+                "update-notifier": "^1.0.0",
+                "vinyl": "^1.1.1",
+                "vinyl-fs": "^2.4.3",
+                "web-component-tester": "^6.3.0",
+                "yeoman-environment": "^1.5.2",
+                "yeoman-generator": "^1.0.1"
             },
             "dependencies": {
                 "glob": {
@@ -9489,11 +10387,11 @@
                     "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                     "dev": true,
                     "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.3.3",
-                        "path-is-absolute": "1.0.1"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "glob-parent": {
@@ -9502,8 +10400,8 @@
                     "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
                     "dev": true,
                     "requires": {
-                        "is-glob": "3.1.0",
-                        "path-dirname": "1.0.2"
+                        "is-glob": "^3.1.0",
+                        "path-dirname": "^1.0.0"
                     }
                 },
                 "glob-stream": {
@@ -9512,14 +10410,14 @@
                     "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
                     "dev": true,
                     "requires": {
-                        "extend": "3.0.1",
-                        "glob": "5.0.15",
-                        "glob-parent": "3.1.0",
-                        "micromatch": "2.3.11",
-                        "ordered-read-streams": "0.3.0",
-                        "through2": "0.6.5",
-                        "to-absolute-glob": "0.1.1",
-                        "unique-stream": "2.2.1"
+                        "extend": "^3.0.0",
+                        "glob": "^5.0.3",
+                        "glob-parent": "^3.0.0",
+                        "micromatch": "^2.3.7",
+                        "ordered-read-streams": "^0.3.0",
+                        "through2": "^0.6.0",
+                        "to-absolute-glob": "^0.1.1",
+                        "unique-stream": "^2.0.2"
                     },
                     "dependencies": {
                         "readable-stream": {
@@ -9528,10 +10426,10 @@
                             "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                             "dev": true,
                             "requires": {
-                                "core-util-is": "1.0.2",
-                                "inherits": "2.0.3",
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.1",
                                 "isarray": "0.0.1",
-                                "string_decoder": "0.10.31"
+                                "string_decoder": "~0.10.x"
                             }
                         },
                         "through2": {
@@ -9540,8 +10438,8 @@
                             "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                             "dev": true,
                             "requires": {
-                                "readable-stream": "1.0.34",
-                                "xtend": "4.0.1"
+                                "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                                "xtend": ">=4.0.0 <4.1.0-0"
                             }
                         }
                     }
@@ -9558,7 +10456,7 @@
                     "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "2.1.1"
+                        "is-extglob": "^2.1.0"
                     }
                 },
                 "isarray": {
@@ -9588,8 +10486,8 @@
                     "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
                     "dev": true,
                     "requires": {
-                        "is-stream": "1.1.0",
-                        "readable-stream": "2.3.3"
+                        "is-stream": "^1.0.1",
+                        "readable-stream": "^2.0.1"
                     }
                 },
                 "string_decoder": {
@@ -9604,8 +10502,8 @@
                     "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
                     "dev": true,
                     "requires": {
-                        "json-stable-stringify": "1.0.1",
-                        "through2-filter": "2.0.0"
+                        "json-stable-stringify": "^1.0.0",
+                        "through2-filter": "^2.0.0"
                     }
                 },
                 "vinyl": {
@@ -9614,8 +10512,8 @@
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.3",
-                        "clone-stats": "0.0.1",
+                        "clone": "^1.0.0",
+                        "clone-stats": "^0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 },
@@ -9625,23 +10523,23 @@
                     "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
                     "dev": true,
                     "requires": {
-                        "duplexify": "3.5.1",
-                        "glob-stream": "5.3.5",
-                        "graceful-fs": "4.1.11",
+                        "duplexify": "^3.2.0",
+                        "glob-stream": "^5.3.2",
+                        "graceful-fs": "^4.0.0",
                         "gulp-sourcemaps": "1.6.0",
-                        "is-valid-glob": "0.3.0",
-                        "lazystream": "1.0.0",
-                        "lodash.isequal": "4.5.0",
-                        "merge-stream": "1.0.1",
-                        "mkdirp": "0.5.1",
-                        "object-assign": "4.1.1",
-                        "readable-stream": "2.3.3",
-                        "strip-bom": "2.0.0",
-                        "strip-bom-stream": "1.0.0",
-                        "through2": "2.0.3",
-                        "through2-filter": "2.0.0",
-                        "vali-date": "1.0.0",
-                        "vinyl": "1.2.0"
+                        "is-valid-glob": "^0.3.0",
+                        "lazystream": "^1.0.0",
+                        "lodash.isequal": "^4.0.0",
+                        "merge-stream": "^1.0.0",
+                        "mkdirp": "^0.5.0",
+                        "object-assign": "^4.0.0",
+                        "readable-stream": "^2.0.4",
+                        "strip-bom": "^2.0.0",
+                        "strip-bom-stream": "^1.0.0",
+                        "through2": "^2.0.0",
+                        "through2-filter": "^2.0.0",
+                        "vali-date": "^1.0.0",
+                        "vinyl": "^1.0.0"
                     }
                 }
             }
@@ -9654,16 +10552,16 @@
             "requires": {
                 "@types/estree": "0.0.34",
                 "@types/fast-levenshtein": "0.0.1",
-                "@types/node": "6.0.92",
-                "@types/parse5": "2.2.34",
-                "css-what": "2.1.0",
-                "dom5": "2.3.0",
-                "estraverse": "4.2.0",
-                "fast-levenshtein": "2.0.6",
-                "parse5": "2.2.3",
-                "polymer-analyzer": "2.7.0",
-                "stable": "0.1.6",
-                "strip-indent": "2.0.0"
+                "@types/node": "^6",
+                "@types/parse5": "^2.2.34",
+                "css-what": "^2.1.0",
+                "dom5": "^2.0.0",
+                "estraverse": "^4.2.0",
+                "fast-levenshtein": "^2.0.6",
+                "parse5": "^2.2.1",
+                "polymer-analyzer": "^2.7.0",
+                "stable": "^0.1.6",
+                "strip-indent": "^2.0.0"
             },
             "dependencies": {
                 "@types/estree": {
@@ -9692,10 +10590,10 @@
             "integrity": "sha512-Umz4IfdG6Irahkvb2KOwnF5D8S9KAf35A6Nx5NsDk/CjCiBAsBMMBqszA91sshCVP/p1rxJN8ZgMqz8VoynZJQ==",
             "dev": true,
             "requires": {
-                "@types/node": "6.0.92",
-                "jsonschema": "1.2.0",
-                "minimatch-all": "1.1.0",
-                "plylog": "0.5.0"
+                "@types/node": "^6.0.41",
+                "jsonschema": "^1.1.1",
+                "minimatch-all": "^1.1.0",
+                "plylog": "^0.5.0"
             },
             "dependencies": {
                 "@types/node": {
@@ -9710,9 +10608,9 @@
                     "integrity": "sha1-yXbrodgNLdmRAF18EQ2vh0FUeI8=",
                     "dev": true,
                     "requires": {
-                        "@types/node": "4.2.23",
-                        "@types/winston": "2.3.7",
-                        "winston": "2.4.0"
+                        "@types/node": "^4.2.3",
+                        "@types/winston": "^2.2.0",
+                        "winston": "^2.2.0"
                     },
                     "dependencies": {
                         "@types/node": {
@@ -9732,62 +10630,62 @@
             "dev": true,
             "requires": {
                 "@types/assert": "0.0.29",
-                "@types/babel-core": "6.25.3",
-                "@types/babylon": "6.16.2",
-                "@types/compression": "0.0.33",
-                "@types/content-type": "1.1.2",
-                "@types/express": "4.0.39",
+                "@types/babel-core": "^6.7.14",
+                "@types/babylon": "^6.16.2",
+                "@types/compression": "^0.0.33",
+                "@types/content-type": "^1.1.0",
+                "@types/express": "^4.0.36",
                 "@types/mime": "0.0.29",
                 "@types/mz": "0.0.29",
-                "@types/node": "8.0.53",
-                "@types/opn": "3.0.28",
-                "@types/parse5": "2.2.34",
-                "@types/pem": "1.9.3",
-                "@types/serve-static": "1.13.1",
-                "@types/spdy": "3.4.4",
-                "@types/ua-parser-js": "0.7.32",
-                "babel-core": "6.26.0",
-                "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-                "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-                "babel-plugin-transform-es2015-block-scoping": "6.26.0",
-                "babel-plugin-transform-es2015-classes": "6.24.1",
-                "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-                "babel-plugin-transform-es2015-destructuring": "6.23.0",
-                "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-                "babel-plugin-transform-es2015-for-of": "6.23.0",
-                "babel-plugin-transform-es2015-function-name": "6.24.1",
-                "babel-plugin-transform-es2015-literals": "6.22.0",
-                "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-                "babel-plugin-transform-es2015-object-super": "6.24.1",
-                "babel-plugin-transform-es2015-parameters": "6.24.1",
-                "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-                "babel-plugin-transform-es2015-spread": "6.22.0",
-                "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-                "babel-plugin-transform-es2015-template-literals": "6.22.0",
-                "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-                "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-                "babel-plugin-transform-regenerator": "6.26.0",
-                "babylon": "6.18.0",
-                "browser-capabilities": "0.2.1",
-                "command-line-args": "3.0.5",
-                "command-line-usage": "3.0.8",
-                "compression": "1.7.1",
-                "content-type": "1.0.4",
-                "dom5": "2.3.0",
-                "express": "4.16.2",
-                "find-port": "1.0.1",
-                "http-proxy-middleware": "0.17.4",
-                "lru-cache": "4.1.1",
-                "mime": "1.6.0",
-                "mz": "2.7.0",
-                "opn": "3.0.3",
-                "parse5": "2.2.3",
-                "pem": "1.12.3",
-                "polymer-build": "2.1.1",
-                "requirejs": "2.3.5",
-                "resolve": "1.5.0",
-                "send": "0.14.2",
-                "spdy": "3.4.7"
+                "@types/node": "^8.0.0",
+                "@types/opn": "^3.0.28",
+                "@types/parse5": "^2.2.34",
+                "@types/pem": "^1.8.1",
+                "@types/serve-static": "^1.7.31",
+                "@types/spdy": "^3.4.1",
+                "@types/ua-parser-js": "^0.7.30",
+                "babel-core": "^6.18.2",
+                "babel-plugin-transform-es2015-arrow-functions": "^6.8.0",
+                "babel-plugin-transform-es2015-block-scoped-functions": "^6.8.0",
+                "babel-plugin-transform-es2015-block-scoping": "^6.18.0",
+                "babel-plugin-transform-es2015-classes": "^6.18.0",
+                "babel-plugin-transform-es2015-computed-properties": "^6.8.0",
+                "babel-plugin-transform-es2015-destructuring": "^6.19.0",
+                "babel-plugin-transform-es2015-duplicate-keys": "^6.8.0",
+                "babel-plugin-transform-es2015-for-of": "^6.18.0",
+                "babel-plugin-transform-es2015-function-name": "^6.9.0",
+                "babel-plugin-transform-es2015-literals": "^6.8.0",
+                "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+                "babel-plugin-transform-es2015-object-super": "^6.8.0",
+                "babel-plugin-transform-es2015-parameters": "^6.18.0",
+                "babel-plugin-transform-es2015-shorthand-properties": "^6.18.0",
+                "babel-plugin-transform-es2015-spread": "^6.8.0",
+                "babel-plugin-transform-es2015-sticky-regex": "^6.8.0",
+                "babel-plugin-transform-es2015-template-literals": "^6.8.0",
+                "babel-plugin-transform-es2015-typeof-symbol": "^6.18.0",
+                "babel-plugin-transform-es2015-unicode-regex": "^6.11.0",
+                "babel-plugin-transform-regenerator": "^6.16.1",
+                "babylon": "^6.17.4",
+                "browser-capabilities": "^0.2.0",
+                "command-line-args": "^3.0.1",
+                "command-line-usage": "^3.0.3",
+                "compression": "^1.6.2",
+                "content-type": "^1.0.2",
+                "dom5": "^2.0.1",
+                "express": "^4.8.5",
+                "find-port": "^1.0.1",
+                "http-proxy-middleware": "^0.17.2",
+                "lru-cache": "^4.0.2",
+                "mime": "^1.3.4",
+                "mz": "^2.4.0",
+                "opn": "^3.0.2",
+                "parse5": "^2.2.3",
+                "pem": "^1.8.3",
+                "polymer-build": "^2.1.0",
+                "requirejs": "^2.3.4",
+                "resolve": "^1.0.0",
+                "send": "^0.14.1",
+                "spdy": "^3.3.3"
             },
             "dependencies": {
                 "@types/mz": {
@@ -9796,8 +10694,8 @@
                     "integrity": "sha1-vCRyjGSZc/HHhR6QM/nOUlZowns=",
                     "dev": true,
                     "requires": {
-                        "@types/bluebird": "3.5.18",
-                        "@types/node": "8.0.53"
+                        "@types/bluebird": "*",
+                        "@types/node": "*"
                     }
                 },
                 "debug": {
@@ -9815,36 +10713,36 @@
                     "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
                     "dev": true,
                     "requires": {
-                        "accepts": "1.3.4",
+                        "accepts": "~1.3.4",
                         "array-flatten": "1.1.1",
                         "body-parser": "1.18.2",
                         "content-disposition": "0.5.2",
-                        "content-type": "1.0.4",
+                        "content-type": "~1.0.4",
                         "cookie": "0.3.1",
                         "cookie-signature": "1.0.6",
                         "debug": "2.6.9",
-                        "depd": "1.1.1",
-                        "encodeurl": "1.0.1",
-                        "escape-html": "1.0.3",
-                        "etag": "1.8.1",
+                        "depd": "~1.1.1",
+                        "encodeurl": "~1.0.1",
+                        "escape-html": "~1.0.3",
+                        "etag": "~1.8.1",
                         "finalhandler": "1.1.0",
                         "fresh": "0.5.2",
                         "merge-descriptors": "1.0.1",
-                        "methods": "1.1.2",
-                        "on-finished": "2.3.0",
-                        "parseurl": "1.3.2",
+                        "methods": "~1.1.2",
+                        "on-finished": "~2.3.0",
+                        "parseurl": "~1.3.2",
                         "path-to-regexp": "0.1.7",
-                        "proxy-addr": "2.0.2",
+                        "proxy-addr": "~2.0.2",
                         "qs": "6.5.1",
-                        "range-parser": "1.2.0",
+                        "range-parser": "~1.2.0",
                         "safe-buffer": "5.1.1",
                         "send": "0.16.1",
                         "serve-static": "1.13.1",
                         "setprototypeof": "1.1.0",
-                        "statuses": "1.3.1",
-                        "type-is": "1.6.15",
+                        "statuses": "~1.3.1",
+                        "type-is": "~1.6.15",
                         "utils-merge": "1.0.1",
-                        "vary": "1.1.2"
+                        "vary": "~1.1.2"
                     },
                     "dependencies": {
                         "mime": {
@@ -9860,18 +10758,18 @@
                             "dev": true,
                             "requires": {
                                 "debug": "2.6.9",
-                                "depd": "1.1.1",
-                                "destroy": "1.0.4",
-                                "encodeurl": "1.0.1",
-                                "escape-html": "1.0.3",
-                                "etag": "1.8.1",
+                                "depd": "~1.1.1",
+                                "destroy": "~1.0.4",
+                                "encodeurl": "~1.0.1",
+                                "escape-html": "~1.0.3",
+                                "etag": "~1.8.1",
                                 "fresh": "0.5.2",
-                                "http-errors": "1.6.2",
+                                "http-errors": "~1.6.2",
                                 "mime": "1.4.1",
                                 "ms": "2.0.0",
-                                "on-finished": "2.3.0",
-                                "range-parser": "1.2.0",
-                                "statuses": "1.3.1"
+                                "on-finished": "~2.3.0",
+                                "range-parser": "~1.2.0",
+                                "statuses": "~1.3.1"
                             }
                         }
                     }
@@ -9883,12 +10781,12 @@
                     "dev": true,
                     "requires": {
                         "debug": "2.6.9",
-                        "encodeurl": "1.0.1",
-                        "escape-html": "1.0.3",
-                        "on-finished": "2.3.0",
-                        "parseurl": "1.3.2",
-                        "statuses": "1.3.1",
-                        "unpipe": "1.0.0"
+                        "encodeurl": "~1.0.1",
+                        "escape-html": "~1.0.3",
+                        "on-finished": "~2.3.0",
+                        "parseurl": "~1.3.2",
+                        "statuses": "~1.3.1",
+                        "unpipe": "~1.0.0"
                     }
                 },
                 "fresh": {
@@ -9906,7 +10804,7 @@
                         "depd": "1.1.1",
                         "inherits": "2.0.3",
                         "setprototypeof": "1.0.3",
-                        "statuses": "1.3.1"
+                        "statuses": ">= 1.3.1 < 2"
                     },
                     "dependencies": {
                         "setprototypeof": {
@@ -9923,8 +10821,8 @@
                     "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
                     "dev": true,
                     "requires": {
-                        "pseudomap": "1.0.2",
-                        "yallist": "2.1.2"
+                        "pseudomap": "^1.0.2",
+                        "yallist": "^2.1.2"
                     }
                 },
                 "mime": {
@@ -9945,7 +10843,7 @@
                     "integrity": "sha1-ttmec5n3jWXDuq/+8fsojpuFJDo=",
                     "dev": true,
                     "requires": {
-                        "object-assign": "4.1.1"
+                        "object-assign": "^4.0.1"
                     }
                 },
                 "path-to-regexp": {
@@ -9966,19 +10864,19 @@
                     "integrity": "sha1-ObBDiz9RC+Xcb2Z6EfcWiTaM3u8=",
                     "dev": true,
                     "requires": {
-                        "debug": "2.2.0",
-                        "depd": "1.1.1",
-                        "destroy": "1.0.4",
-                        "encodeurl": "1.0.1",
-                        "escape-html": "1.0.3",
-                        "etag": "1.7.0",
+                        "debug": "~2.2.0",
+                        "depd": "~1.1.0",
+                        "destroy": "~1.0.4",
+                        "encodeurl": "~1.0.1",
+                        "escape-html": "~1.0.3",
+                        "etag": "~1.7.0",
                         "fresh": "0.3.0",
-                        "http-errors": "1.5.1",
+                        "http-errors": "~1.5.1",
                         "mime": "1.3.4",
                         "ms": "0.7.2",
-                        "on-finished": "2.3.0",
-                        "range-parser": "1.2.0",
-                        "statuses": "1.3.1"
+                        "on-finished": "~2.3.0",
+                        "range-parser": "~1.2.0",
+                        "statuses": "~1.3.1"
                     },
                     "dependencies": {
                         "debug": {
@@ -10018,7 +10916,7 @@
                             "requires": {
                                 "inherits": "2.0.3",
                                 "setprototypeof": "1.0.2",
-                                "statuses": "1.3.1"
+                                "statuses": ">= 1.3.1 < 2"
                             }
                         },
                         "mime": {
@@ -10047,9 +10945,9 @@
                     "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
                     "dev": true,
                     "requires": {
-                        "encodeurl": "1.0.1",
-                        "escape-html": "1.0.3",
-                        "parseurl": "1.3.2",
+                        "encodeurl": "~1.0.1",
+                        "escape-html": "~1.0.3",
+                        "parseurl": "~1.3.2",
                         "send": "0.16.1"
                     },
                     "dependencies": {
@@ -10066,18 +10964,18 @@
                             "dev": true,
                             "requires": {
                                 "debug": "2.6.9",
-                                "depd": "1.1.1",
-                                "destroy": "1.0.4",
-                                "encodeurl": "1.0.1",
-                                "escape-html": "1.0.3",
-                                "etag": "1.8.1",
+                                "depd": "~1.1.1",
+                                "destroy": "~1.0.4",
+                                "encodeurl": "~1.0.1",
+                                "escape-html": "~1.0.3",
+                                "etag": "~1.8.1",
                                 "fresh": "0.5.2",
-                                "http-errors": "1.6.2",
+                                "http-errors": "~1.6.2",
                                 "mime": "1.4.1",
                                 "ms": "2.0.0",
-                                "on-finished": "2.3.0",
-                                "range-parser": "1.2.0",
-                                "statuses": "1.3.1"
+                                "on-finished": "~2.3.0",
+                                "range-parser": "~1.2.0",
+                                "statuses": "~1.3.1"
                             }
                         }
                     }
@@ -10103,8 +11001,14 @@
             "dev": true,
             "requires": {
                 "async": "1.5.2",
-                "is-number-like": "1.0.8"
+                "is-number-like": "^1.0.3"
             }
+        },
+        "posix-character-classes": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+            "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+            "dev": true
         },
         "postcss": {
             "version": "5.2.18",
@@ -10112,10 +11016,10 @@
             "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "js-base64": "2.3.2",
-                "source-map": "0.5.7",
-                "supports-color": "3.2.3"
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
             },
             "dependencies": {
                 "supports-color": {
@@ -10124,7 +11028,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -10190,8 +11094,8 @@
             "integrity": "sha1-MoA4dOxBF4TkeGwzmQKoeheaRpw=",
             "dev": true,
             "requires": {
-                "nodegit-promise": "4.0.0",
-                "object-assign": "4.1.1"
+                "nodegit-promise": "~4.0.0",
+                "object-assign": "^4.0.1"
             }
         },
         "proxy-addr": {
@@ -10200,7 +11104,7 @@
             "integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
             "dev": true,
             "requires": {
-                "forwarded": "0.1.2",
+                "forwarded": "~0.1.2",
                 "ipaddr.js": "1.5.2"
             }
         },
@@ -10216,8 +11120,8 @@
             "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
             "dev": true,
             "requires": {
-                "end-of-stream": "1.4.0",
-                "once": "1.3.3"
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
             },
             "dependencies": {
                 "end-of-stream": {
@@ -10226,7 +11130,7 @@
                     "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
                     "dev": true,
                     "requires": {
-                        "once": "1.4.0"
+                        "once": "^1.4.0"
                     },
                     "dependencies": {
                         "once": {
@@ -10235,7 +11139,7 @@
                             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                             "dev": true,
                             "requires": {
-                                "wrappy": "1.0.2"
+                                "wrappy": "1"
                             }
                         }
                     }
@@ -10248,9 +11152,9 @@
             "integrity": "sha1-G2ccYZlAq8rqwK0OOjwWS+dgmTs=",
             "dev": true,
             "requires": {
-                "duplexify": "3.5.1",
-                "inherits": "2.0.3",
-                "pump": "1.0.3"
+                "duplexify": "^3.1.2",
+                "inherits": "^2.0.1",
+                "pump": "^1.0.0"
             }
         },
         "punycode": {
@@ -10278,8 +11182,8 @@
             "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
             "dev": true,
             "requires": {
-                "is-number": "3.0.0",
-                "kind-of": "4.0.0"
+                "is-number": "^3.0.0",
+                "kind-of": "^4.0.0"
             },
             "dependencies": {
                 "is-number": {
@@ -10288,7 +11192,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -10297,7 +11201,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -10308,7 +11212,7 @@
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -10340,7 +11244,7 @@
                         "depd": "1.1.1",
                         "inherits": "2.0.3",
                         "setprototypeof": "1.0.3",
-                        "statuses": "1.3.1"
+                        "statuses": ">= 1.3.1 < 2"
                     }
                 },
                 "setprototypeof": {
@@ -10357,10 +11261,10 @@
             "integrity": "sha1-2M6ctX6NZNnHut2YdsfDTL48cHc=",
             "dev": true,
             "requires": {
-                "deep-extend": "0.4.2",
-                "ini": "1.3.5",
-                "minimist": "1.2.0",
-                "strip-json-comments": "2.0.1"
+                "deep-extend": "~0.4.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
             }
         },
         "read-all-stream": {
@@ -10369,8 +11273,8 @@
             "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
             "dev": true,
             "requires": {
-                "pinkie-promise": "2.0.1",
-                "readable-stream": "2.3.3"
+                "pinkie-promise": "^2.0.0",
+                "readable-stream": "^2.0.0"
             }
         },
         "read-chunk": {
@@ -10379,8 +11283,8 @@
             "integrity": "sha1-agTAkoAF7Z1C4aasVgDhnLx/9lU=",
             "dev": true,
             "requires": {
-                "pify": "3.0.0",
-                "safe-buffer": "5.1.1"
+                "pify": "^3.0.0",
+                "safe-buffer": "^5.1.1"
             },
             "dependencies": {
                 "pify": {
@@ -10397,9 +11301,9 @@
             "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
             "dev": true,
             "requires": {
-                "load-json-file": "1.1.0",
-                "normalize-package-data": "2.4.0",
-                "path-type": "1.1.0"
+                "load-json-file": "^1.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^1.0.0"
             }
         },
         "read-pkg-up": {
@@ -10408,8 +11312,8 @@
             "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
             "dev": true,
             "requires": {
-                "find-up": "1.1.2",
-                "read-pkg": "1.1.0"
+                "find-up": "^1.0.0",
+                "read-pkg": "^1.0.0"
             }
         },
         "readable-stream": {
@@ -10418,13 +11322,13 @@
             "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
             "dev": true,
             "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "safe-buffer": "5.1.1",
-                "string_decoder": "1.0.3",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~1.0.6",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.0.3",
+                "util-deprecate": "~1.0.1"
             }
         },
         "readdirp": {
@@ -10433,10 +11337,10 @@
             "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "minimatch": "3.0.4",
-                "readable-stream": "2.3.3",
-                "set-immediate-shim": "1.0.1"
+                "graceful-fs": "^4.1.2",
+                "minimatch": "^3.0.2",
+                "readable-stream": "^2.0.2",
+                "set-immediate-shim": "^1.0.1"
             }
         },
         "rechoir": {
@@ -10445,7 +11349,7 @@
             "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
             "dev": true,
             "requires": {
-                "resolve": "1.5.0"
+                "resolve": "^1.1.6"
             }
         },
         "redent": {
@@ -10454,8 +11358,8 @@
             "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
             "dev": true,
             "requires": {
-                "indent-string": "2.1.0",
-                "strip-indent": "1.0.1"
+                "indent-string": "^2.1.0",
+                "strip-indent": "^1.0.1"
             }
         },
         "reduce-flatten": {
@@ -10482,9 +11386,9 @@
             "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0",
-                "private": "0.1.8"
+                "babel-runtime": "^6.18.0",
+                "babel-types": "^6.19.0",
+                "private": "^0.1.6"
             }
         },
         "regex-cache": {
@@ -10493,7 +11397,38 @@
             "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
             "dev": true,
             "requires": {
-                "is-equal-shallow": "0.1.3"
+                "is-equal-shallow": "^0.1.3"
+            }
+        },
+        "regex-not": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+            "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+            "dev": true,
+            "requires": {
+                "extend-shallow": "^3.0.2",
+                "safe-regex": "^1.1.0"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+                    "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+                    "dev": true,
+                    "requires": {
+                        "assign-symbols": "^1.0.0",
+                        "is-extendable": "^1.0.1"
+                    }
+                },
+                "is-extendable": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+                    "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                    "dev": true,
+                    "requires": {
+                        "is-plain-object": "^2.0.4"
+                    }
+                }
             }
         },
         "regexpu-core": {
@@ -10502,9 +11437,9 @@
             "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
             "dev": true,
             "requires": {
-                "regenerate": "1.3.3",
-                "regjsgen": "0.2.0",
-                "regjsparser": "0.1.5"
+                "regenerate": "^1.2.1",
+                "regjsgen": "^0.2.0",
+                "regjsparser": "^0.1.4"
             }
         },
         "registry-auth-token": {
@@ -10513,8 +11448,8 @@
             "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
             "dev": true,
             "requires": {
-                "rc": "1.2.2",
-                "safe-buffer": "5.1.1"
+                "rc": "^1.1.6",
+                "safe-buffer": "^5.0.1"
             }
         },
         "registry-url": {
@@ -10523,7 +11458,7 @@
             "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
             "dev": true,
             "requires": {
-                "rc": "1.2.2"
+                "rc": "^1.0.1"
             }
         },
         "regjsgen": {
@@ -10538,7 +11473,7 @@
             "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
             "dev": true,
             "requires": {
-                "jsesc": "0.5.0"
+                "jsesc": "~0.5.0"
             },
             "dependencies": {
                 "jsesc": {
@@ -10579,7 +11514,7 @@
             "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
             "dev": true,
             "requires": {
-                "is-finite": "1.0.2"
+                "is-finite": "^1.0.0"
             }
         },
         "replace-ext": {
@@ -10594,28 +11529,28 @@
             "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
             "dev": true,
             "requires": {
-                "aws-sign2": "0.6.0",
-                "aws4": "1.6.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.5",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.1.4",
-                "har-validator": "4.2.1",
-                "hawk": "3.1.3",
-                "http-signature": "1.1.1",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.17",
-                "oauth-sign": "0.8.2",
-                "performance-now": "0.2.0",
-                "qs": "6.4.0",
-                "safe-buffer": "5.1.1",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.3.3",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.1.0"
+                "aws-sign2": "~0.6.0",
+                "aws4": "^1.2.1",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.5",
+                "extend": "~3.0.0",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.1.1",
+                "har-validator": "~4.2.1",
+                "hawk": "~3.1.3",
+                "http-signature": "~1.1.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.7",
+                "oauth-sign": "~0.8.1",
+                "performance-now": "^0.2.0",
+                "qs": "~6.4.0",
+                "safe-buffer": "^5.0.1",
+                "stringstream": "~0.0.4",
+                "tough-cookie": "~2.3.0",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.0.0"
             },
             "dependencies": {
                 "qs": {
@@ -10656,7 +11591,7 @@
             "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
             "dev": true,
             "requires": {
-                "path-parse": "1.0.5"
+                "path-parse": "^1.0.5"
             }
         },
         "resolve-dir": {
@@ -10665,9 +11600,15 @@
             "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
             "dev": true,
             "requires": {
-                "expand-tilde": "1.2.2",
-                "global-modules": "0.2.3"
+                "expand-tilde": "^1.2.2",
+                "global-modules": "^0.2.3"
             }
+        },
+        "resolve-url": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+            "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+            "dev": true
         },
         "resp-modifier": {
             "version": "6.0.2",
@@ -10675,8 +11616,8 @@
             "integrity": "sha1-sSTeXE+6/LpUH0j/pzlw9KpFa08=",
             "dev": true,
             "requires": {
-                "debug": "2.2.0",
-                "minimatch": "3.0.4"
+                "debug": "^2.2.0",
+                "minimatch": "^3.0.2"
             }
         },
         "restore-cursor": {
@@ -10685,9 +11626,15 @@
             "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
             "dev": true,
             "requires": {
-                "exit-hook": "1.1.1",
-                "onetime": "1.1.0"
+                "exit-hook": "^1.0.0",
+                "onetime": "^1.0.0"
             }
+        },
+        "ret": {
+            "version": "0.1.15",
+            "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+            "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+            "dev": true
         },
         "rimraf": {
             "version": "2.6.2",
@@ -10695,7 +11642,7 @@
             "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
             "dev": true,
             "requires": {
-                "glob": "7.1.2"
+                "glob": "^7.0.5"
             },
             "dependencies": {
                 "glob": {
@@ -10704,12 +11651,12 @@
                     "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.3.3",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 }
             }
@@ -10720,7 +11667,7 @@
             "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
             "dev": true,
             "requires": {
-                "is-promise": "2.1.0"
+                "is-promise": "^2.1.0"
             }
         },
         "rx": {
@@ -10735,6 +11682,15 @@
             "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
             "dev": true
         },
+        "safe-regex": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+            "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+            "dev": true,
+            "requires": {
+                "ret": "~0.1.10"
+            }
+        },
         "samsam": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
@@ -10747,10 +11703,10 @@
             "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
             "dev": true,
             "requires": {
-                "glob": "7.1.2",
-                "lodash": "4.17.4",
-                "scss-tokenizer": "0.2.3",
-                "yargs": "7.1.0"
+                "glob": "^7.0.0",
+                "lodash": "^4.0.0",
+                "scss-tokenizer": "^0.2.3",
+                "yargs": "^7.0.0"
             },
             "dependencies": {
                 "camelcase": {
@@ -10765,12 +11721,12 @@
                     "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.3.3",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "lodash": {
@@ -10785,19 +11741,19 @@
                     "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "3.0.0",
-                        "cliui": "3.2.0",
-                        "decamelize": "1.2.0",
-                        "get-caller-file": "1.0.2",
-                        "os-locale": "1.4.0",
-                        "read-pkg-up": "1.0.1",
-                        "require-directory": "2.1.1",
-                        "require-main-filename": "1.0.1",
-                        "set-blocking": "2.0.0",
-                        "string-width": "1.0.2",
-                        "which-module": "1.0.0",
-                        "y18n": "3.2.1",
-                        "yargs-parser": "5.0.0"
+                        "camelcase": "^3.0.0",
+                        "cliui": "^3.2.0",
+                        "decamelize": "^1.1.1",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^1.4.0",
+                        "read-pkg-up": "^1.0.1",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^1.0.2",
+                        "which-module": "^1.0.0",
+                        "y18n": "^3.2.1",
+                        "yargs-parser": "^5.0.0"
                     }
                 },
                 "yargs-parser": {
@@ -10806,7 +11762,7 @@
                     "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "3.0.0"
+                        "camelcase": "^3.0.0"
                     }
                 }
             }
@@ -10818,11 +11774,11 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "adm-zip": "0.4.7",
-                "async": "2.6.0",
-                "https-proxy-agent": "1.0.0",
-                "lodash": "4.17.4",
-                "rimraf": "2.6.2"
+                "adm-zip": "~0.4.3",
+                "async": "^2.1.2",
+                "https-proxy-agent": "~1.0.0",
+                "lodash": "^4.16.6",
+                "rimraf": "^2.5.4"
             },
             "dependencies": {
                 "async": {
@@ -10832,7 +11788,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "lodash": "4.17.4"
+                        "lodash": "^4.14.0"
                     }
                 },
                 "lodash": {
@@ -10849,8 +11805,8 @@
             "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
             "dev": true,
             "requires": {
-                "js-base64": "2.3.2",
-                "source-map": "0.4.4"
+                "js-base64": "^2.1.8",
+                "source-map": "^0.4.2"
             },
             "dependencies": {
                 "source-map": {
@@ -10859,7 +11815,7 @@
                     "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
                     "dev": true,
                     "requires": {
-                        "amdefine": "1.0.1"
+                        "amdefine": ">=0.0.4"
                     }
                 }
             }
@@ -10887,7 +11843,7 @@
                 "tar-stream": "1.5.2",
                 "urijs": "1.16.1",
                 "which": "1.1.1",
-                "yauzl": "2.9.1"
+                "yauzl": "^2.5.0"
             },
             "dependencies": {
                 "async": {
@@ -10918,7 +11874,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "once": "1.4.0"
+                        "once": "^1.4.0"
                     }
                 },
                 "har-validator": {
@@ -10928,10 +11884,10 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "commander": "2.12.2",
-                        "is-my-json-valid": "2.16.1",
-                        "pinkie-promise": "2.0.1"
+                        "chalk": "^1.1.1",
+                        "commander": "^2.9.0",
+                        "is-my-json-valid": "^2.12.4",
+                        "pinkie-promise": "^2.0.0"
                     },
                     "dependencies": {
                         "commander": {
@@ -10950,7 +11906,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "is-relative": "0.1.3"
+                        "is-relative": "^0.1.0"
                     }
                 },
                 "is-relative": {
@@ -11000,7 +11956,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                     }
                 },
                 "qs": {
@@ -11017,26 +11973,26 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "aws-sign2": "0.6.0",
-                        "aws4": "1.6.0",
-                        "caseless": "0.11.0",
-                        "combined-stream": "1.0.5",
-                        "extend": "3.0.1",
-                        "forever-agent": "0.6.1",
-                        "form-data": "2.1.4",
-                        "har-validator": "2.0.6",
-                        "hawk": "3.1.3",
-                        "http-signature": "1.1.1",
-                        "is-typedarray": "1.0.0",
-                        "isstream": "0.1.2",
-                        "json-stringify-safe": "5.0.1",
-                        "mime-types": "2.1.17",
-                        "oauth-sign": "0.8.2",
-                        "qs": "6.3.2",
-                        "stringstream": "0.0.5",
-                        "tough-cookie": "2.3.3",
-                        "tunnel-agent": "0.4.3",
-                        "uuid": "3.1.0"
+                        "aws-sign2": "~0.6.0",
+                        "aws4": "^1.2.1",
+                        "caseless": "~0.11.0",
+                        "combined-stream": "~1.0.5",
+                        "extend": "~3.0.0",
+                        "forever-agent": "~0.6.1",
+                        "form-data": "~2.1.1",
+                        "har-validator": "~2.0.6",
+                        "hawk": "~3.1.3",
+                        "http-signature": "~1.1.0",
+                        "is-typedarray": "~1.0.0",
+                        "isstream": "~0.1.2",
+                        "json-stringify-safe": "~5.0.1",
+                        "mime-types": "~2.1.7",
+                        "oauth-sign": "~0.8.1",
+                        "qs": "~6.3.0",
+                        "stringstream": "~0.0.4",
+                        "tough-cookie": "~2.3.0",
+                        "tunnel-agent": "~0.4.1",
+                        "uuid": "^3.0.0"
                     }
                 },
                 "tar-stream": {
@@ -11046,10 +12002,10 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "bl": "1.2.1",
-                        "end-of-stream": "1.4.0",
-                        "readable-stream": "2.3.3",
-                        "xtend": "4.0.1"
+                        "bl": "^1.0.0",
+                        "end-of-stream": "^1.0.0",
+                        "readable-stream": "^2.0.0",
+                        "xtend": "^4.0.0"
                     }
                 },
                 "tunnel-agent": {
@@ -11073,7 +12029,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "is-absolute": "0.1.7"
+                        "is-absolute": "^0.1.7"
                     }
                 }
             }
@@ -11090,7 +12046,7 @@
             "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
             "dev": true,
             "requires": {
-                "semver": "5.4.1"
+                "semver": "^5.0.3"
             }
         },
         "send": {
@@ -11100,18 +12056,18 @@
             "dev": true,
             "requires": {
                 "debug": "2.6.4",
-                "depd": "1.1.1",
-                "destroy": "1.0.4",
-                "encodeurl": "1.0.1",
-                "escape-html": "1.0.3",
-                "etag": "1.8.1",
+                "depd": "~1.1.0",
+                "destroy": "~1.0.4",
+                "encodeurl": "~1.0.1",
+                "escape-html": "~1.0.3",
+                "etag": "~1.8.0",
                 "fresh": "0.5.0",
-                "http-errors": "1.6.2",
+                "http-errors": "~1.6.1",
                 "mime": "1.3.4",
                 "ms": "1.0.0",
-                "on-finished": "2.3.0",
-                "range-parser": "1.2.0",
-                "statuses": "1.3.1"
+                "on-finished": "~2.3.0",
+                "range-parser": "~1.2.0",
+                "statuses": "~1.3.1"
             },
             "dependencies": {
                 "debug": {
@@ -11146,7 +12102,7 @@
                         "depd": "1.1.1",
                         "inherits": "2.0.3",
                         "setprototypeof": "1.0.3",
-                        "statuses": "1.3.1"
+                        "statuses": ">= 1.3.1 < 2"
                     }
                 },
                 "mime": {
@@ -11181,13 +12137,13 @@
             "integrity": "sha1-fF2WwT+xMRAfk8HFd0+FFqHnjTs=",
             "dev": true,
             "requires": {
-                "accepts": "1.3.4",
+                "accepts": "~1.3.3",
                 "batch": "0.5.3",
-                "debug": "2.2.0",
-                "escape-html": "1.0.3",
-                "http-errors": "1.5.1",
-                "mime-types": "2.1.17",
-                "parseurl": "1.3.2"
+                "debug": "~2.2.0",
+                "escape-html": "~1.0.3",
+                "http-errors": "~1.5.0",
+                "mime-types": "~2.1.11",
+                "parseurl": "~1.3.1"
             }
         },
         "serve-static": {
@@ -11196,9 +12152,9 @@
             "integrity": "sha1-5UbicmCBuBtLzsjpCAjrzdMjr7o=",
             "dev": true,
             "requires": {
-                "encodeurl": "1.0.1",
-                "escape-html": "1.0.3",
-                "parseurl": "1.3.2",
+                "encodeurl": "~1.0.1",
+                "escape-html": "~1.0.3",
+                "parseurl": "~1.3.1",
                 "send": "0.15.2"
             }
         },
@@ -11226,6 +12182,29 @@
             "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
             "dev": true
         },
+        "set-value": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+            "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+            "dev": true,
+            "requires": {
+                "extend-shallow": "^2.0.1",
+                "is-extendable": "^0.1.1",
+                "is-plain-object": "^2.0.3",
+                "split-string": "^3.0.1"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                }
+            }
+        },
         "setprototypeof": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz",
@@ -11244,7 +12223,7 @@
             "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
             "dev": true,
             "requires": {
-                "shebang-regex": "1.0.0"
+                "shebang-regex": "^1.0.0"
             }
         },
         "shebang-regex": {
@@ -11259,9 +12238,9 @@
             "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
             "dev": true,
             "requires": {
-                "glob": "7.1.2",
-                "interpret": "1.1.0",
-                "rechoir": "0.6.2"
+                "glob": "^7.0.0",
+                "interpret": "^1.0.0",
+                "rechoir": "^0.6.2"
             },
             "dependencies": {
                 "glob": {
@@ -11270,12 +12249,12 @@
                     "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.3.3",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 }
             }
@@ -11298,14 +12277,14 @@
             "integrity": "sha512-vFTrO9Wt0ECffDYIPSP/E5bBugt0UjcBQOfQUMh66xzkyPEnhl/vM2LRZi2ajuTdkH07sA6DzrM6KvdvGIH8xw==",
             "dev": true,
             "requires": {
-                "diff": "3.2.0",
+                "diff": "^3.1.0",
                 "formatio": "1.2.0",
-                "lolex": "1.6.0",
-                "native-promise-only": "0.8.1",
-                "path-to-regexp": "1.7.0",
-                "samsam": "1.3.0",
+                "lolex": "^1.6.0",
+                "native-promise-only": "^0.8.1",
+                "path-to-regexp": "^1.7.0",
+                "samsam": "^1.1.3",
                 "text-encoding": "0.6.4",
-                "type-detect": "4.0.5"
+                "type-detect": "^4.0.0"
             }
         },
         "sinon-chai": {
@@ -11326,13 +12305,121 @@
             "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
             "dev": true
         },
+        "snapdragon": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+            "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+            "dev": true,
+            "requires": {
+                "base": "^0.11.1",
+                "debug": "^2.2.0",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "map-cache": "^0.2.2",
+                "source-map": "^0.5.6",
+                "source-map-resolve": "^0.5.0",
+                "use": "^3.1.0"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^0.1.0"
+                    }
+                },
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                }
+            }
+        },
+        "snapdragon-node": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+            "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+            "dev": true,
+            "requires": {
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.0",
+                "snapdragon-util": "^3.0.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                    "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^1.0.0"
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
+                    }
+                },
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
+                },
+                "kind-of": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+                    "dev": true
+                }
+            }
+        },
+        "snapdragon-util": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+            "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+            "dev": true,
+            "requires": {
+                "kind-of": "^3.2.0"
+            }
+        },
         "sntp": {
             "version": "1.0.9",
             "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
             "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
             "dev": true,
             "requires": {
-                "hoek": "2.16.3"
+                "hoek": "2.x.x"
             }
         },
         "socket.io": {
@@ -11468,7 +12555,7 @@
             "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
             "dev": true,
             "requires": {
-                "is-plain-obj": "1.1.0"
+                "is-plain-obj": "^1.0.0"
             }
         },
         "sort-keys-length": {
@@ -11477,7 +12564,7 @@
             "integrity": "sha1-nLb09OnkgVWmqgZx7dM2/xR5oYg=",
             "dev": true,
             "requires": {
-                "sort-keys": "1.1.2"
+                "sort-keys": "^1.0.0"
             }
         },
         "source-map": {
@@ -11486,14 +12573,33 @@
             "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
             "dev": true
         },
+        "source-map-resolve": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+            "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+            "dev": true,
+            "requires": {
+                "atob": "^2.1.1",
+                "decode-uri-component": "^0.2.0",
+                "resolve-url": "^0.2.1",
+                "source-map-url": "^0.4.0",
+                "urix": "^0.1.0"
+            }
+        },
         "source-map-support": {
             "version": "0.4.18",
             "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
             "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
             "dev": true,
             "requires": {
-                "source-map": "0.5.7"
+                "source-map": "^0.5.6"
             }
+        },
+        "source-map-url": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+            "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+            "dev": true
         },
         "sparkles": {
             "version": "1.0.0",
@@ -11507,8 +12613,8 @@
             "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
             "dev": true,
             "requires": {
-                "concat-stream": "1.6.0",
-                "os-shim": "0.1.3"
+                "concat-stream": "^1.4.7",
+                "os-shim": "^0.1.2"
             }
         },
         "spdx-correct": {
@@ -11517,7 +12623,7 @@
             "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
             "dev": true,
             "requires": {
-                "spdx-license-ids": "1.2.2"
+                "spdx-license-ids": "^1.0.2"
             }
         },
         "spdx-expression-parse": {
@@ -11538,12 +12644,12 @@
             "integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
             "dev": true,
             "requires": {
-                "debug": "2.6.9",
-                "handle-thing": "1.2.5",
-                "http-deceiver": "1.2.7",
-                "safe-buffer": "5.1.1",
-                "select-hose": "2.0.0",
-                "spdy-transport": "2.0.20"
+                "debug": "^2.6.8",
+                "handle-thing": "^1.2.5",
+                "http-deceiver": "^1.2.7",
+                "safe-buffer": "^5.0.1",
+                "select-hose": "^2.0.0",
+                "spdy-transport": "^2.0.18"
             },
             "dependencies": {
                 "debug": {
@@ -11569,13 +12675,13 @@
             "integrity": "sha1-c15yBUxIayNU/onnAiVgBKOazk0=",
             "dev": true,
             "requires": {
-                "debug": "2.6.9",
-                "detect-node": "2.0.3",
-                "hpack.js": "2.1.6",
-                "obuf": "1.1.1",
-                "readable-stream": "2.3.3",
-                "safe-buffer": "5.1.1",
-                "wbuf": "1.7.2"
+                "debug": "^2.6.8",
+                "detect-node": "^2.0.3",
+                "hpack.js": "^2.1.6",
+                "obuf": "^1.1.1",
+                "readable-stream": "^2.2.9",
+                "safe-buffer": "^5.0.1",
+                "wbuf": "^1.7.2"
             },
             "dependencies": {
                 "debug": {
@@ -11595,6 +12701,36 @@
                 }
             }
         },
+        "split-string": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+            "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+            "dev": true,
+            "requires": {
+                "extend-shallow": "^3.0.0"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+                    "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+                    "dev": true,
+                    "requires": {
+                        "assign-symbols": "^1.0.0",
+                        "is-extendable": "^1.0.1"
+                    }
+                },
+                "is-extendable": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+                    "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                    "dev": true,
+                    "requires": {
+                        "is-plain-object": "^2.0.4"
+                    }
+                }
+            }
+        },
         "sprintf-js": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -11607,14 +12743,14 @@
             "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
             "dev": true,
             "requires": {
-                "asn1": "0.2.3",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.1",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.1",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "tweetnacl": "0.14.5"
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "tweetnacl": "~0.14.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -11643,8 +12779,29 @@
             "integrity": "sha1-PxF+UYe5pz0j+HbWnwXIWxGAShI=",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "lodash": "3.10.1"
+                "chalk": "^1.1.1",
+                "lodash": "^3.0.0"
+            }
+        },
+        "static-extend": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+            "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+            "dev": true,
+            "requires": {
+                "define-property": "^0.2.5",
+                "object-copy": "^0.1.0"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^0.1.0"
+                    }
+                }
             }
         },
         "statuses": {
@@ -11659,8 +12816,8 @@
             "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
             "dev": true,
             "requires": {
-                "duplexer2": "0.1.4",
-                "readable-stream": "2.3.3"
+                "duplexer2": "~0.1.0",
+                "readable-stream": "^2.0.2"
             },
             "dependencies": {
                 "duplexer2": {
@@ -11669,7 +12826,7 @@
                     "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "2.3.3"
+                        "readable-stream": "^2.0.2"
                     }
                 }
             }
@@ -11692,8 +12849,8 @@
             "integrity": "sha1-rdV8jXzHOoFjDTHNVdOWHPr7qcM=",
             "dev": true,
             "requires": {
-                "commander": "2.12.2",
-                "limiter": "1.1.2"
+                "commander": "^2.2.0",
+                "limiter": "^1.0.5"
             }
         },
         "streamsearch": {
@@ -11714,9 +12871,9 @@
             "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
             "dev": true,
             "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
             }
         },
         "string_decoder": {
@@ -11725,7 +12882,7 @@
             "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
             "dev": true,
             "requires": {
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "~5.1.0"
             }
         },
         "stringstream": {
@@ -11740,7 +12897,7 @@
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "dev": true,
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
         },
         "strip-bom": {
@@ -11749,7 +12906,7 @@
             "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
             "dev": true,
             "requires": {
-                "is-utf8": "0.2.1"
+                "is-utf8": "^0.2.0"
             }
         },
         "strip-bom-stream": {
@@ -11758,8 +12915,8 @@
             "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
             "dev": true,
             "requires": {
-                "first-chunk-stream": "1.0.0",
-                "strip-bom": "2.0.0"
+                "first-chunk-stream": "^1.0.0",
+                "strip-bom": "^2.0.0"
             }
         },
         "strip-eof": {
@@ -11775,7 +12932,7 @@
             "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
             "dev": true,
             "requires": {
-                "get-stdin": "4.0.1"
+                "get-stdin": "^4.0.1"
             }
         },
         "strip-json-comments": {
@@ -11796,16 +12953,16 @@
             "integrity": "sha512-sKctdX+5hUxkqJ/1DM88ubQ+QRvyw7CnxWdk909N2DgvxMqc1gcQFrwL7zpVc87wFmCA/OvRQd0iMC2XdFopYg==",
             "dev": true,
             "requires": {
-                "dom-urls": "1.1.0",
-                "es6-promise": "4.1.1",
-                "glob": "7.1.2",
-                "lodash.defaults": "4.2.0",
-                "lodash.template": "4.4.0",
-                "meow": "3.7.0",
-                "mkdirp": "0.5.1",
-                "pretty-bytes": "4.0.2",
-                "sw-toolbox": "3.6.0",
-                "update-notifier": "1.0.3"
+                "dom-urls": "^1.1.0",
+                "es6-promise": "^4.0.5",
+                "glob": "^7.1.1",
+                "lodash.defaults": "^4.2.0",
+                "lodash.template": "^4.4.0",
+                "meow": "^3.7.0",
+                "mkdirp": "^0.5.1",
+                "pretty-bytes": "^4.0.2",
+                "sw-toolbox": "^3.4.0",
+                "update-notifier": "^1.0.3"
             },
             "dependencies": {
                 "glob": {
@@ -11814,12 +12971,12 @@
                     "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.3.3",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "lodash.defaults": {
@@ -11834,8 +12991,8 @@
                     "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
                     "dev": true,
                     "requires": {
-                        "lodash._reinterpolate": "3.0.0",
-                        "lodash.templatesettings": "4.1.0"
+                        "lodash._reinterpolate": "~3.0.0",
+                        "lodash.templatesettings": "^4.0.0"
                     }
                 },
                 "lodash.templatesettings": {
@@ -11844,7 +13001,7 @@
                     "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
                     "dev": true,
                     "requires": {
-                        "lodash._reinterpolate": "3.0.0"
+                        "lodash._reinterpolate": "~3.0.0"
                     }
                 },
                 "minimist": {
@@ -11870,8 +13027,8 @@
             "integrity": "sha1-Jt8dHHA0hljk3qKIQxkUm3sxg7U=",
             "dev": true,
             "requires": {
-                "path-to-regexp": "1.7.0",
-                "serviceworker-cache-polyfill": "4.0.0"
+                "path-to-regexp": "^1.0.1",
+                "serviceworker-cache-polyfill": "^4.0.0"
             }
         },
         "table-layout": {
@@ -11880,12 +13037,12 @@
             "integrity": "sha1-buINxIPbNxs+XIf3BO0vfHmdLJo=",
             "dev": true,
             "requires": {
-                "array-back": "1.0.4",
-                "core-js": "2.5.1",
-                "deep-extend": "0.4.2",
-                "feature-detect-es6": "1.3.1",
-                "typical": "2.6.1",
-                "wordwrapjs": "2.0.0"
+                "array-back": "^1.0.3",
+                "core-js": "^2.4.1",
+                "deep-extend": "~0.4.1",
+                "feature-detect-es6": "^1.3.1",
+                "typical": "^2.6.0",
+                "wordwrapjs": "^2.0.0-0"
             }
         },
         "tar": {
@@ -11894,9 +13051,9 @@
             "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
             "dev": true,
             "requires": {
-                "block-stream": "0.0.9",
-                "fstream": "1.0.11",
-                "inherits": "2.0.3"
+                "block-stream": "*",
+                "fstream": "^1.0.2",
+                "inherits": "2"
             }
         },
         "tar-fs": {
@@ -11905,10 +13062,10 @@
             "integrity": "sha512-I9rb6v7mjWLtOfCau9eH5L7sLJyU2BnxtEZRQ5Mt+eRKmf1F0ohXmT/Jc3fr52kDvjJ/HV5MH3soQfPL5bQ0Yg==",
             "dev": true,
             "requires": {
-                "chownr": "1.0.1",
-                "mkdirp": "0.5.1",
-                "pump": "1.0.3",
-                "tar-stream": "1.5.5"
+                "chownr": "^1.0.1",
+                "mkdirp": "^0.5.1",
+                "pump": "^1.0.0",
+                "tar-stream": "^1.1.2"
             },
             "dependencies": {
                 "minimist": {
@@ -11934,10 +13091,10 @@
             "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
             "dev": true,
             "requires": {
-                "bl": "1.2.1",
-                "end-of-stream": "1.4.0",
-                "readable-stream": "2.3.3",
-                "xtend": "4.0.1"
+                "bl": "^1.0.0",
+                "end-of-stream": "^1.0.0",
+                "readable-stream": "^2.0.0",
+                "xtend": "^4.0.0"
             },
             "dependencies": {
                 "end-of-stream": {
@@ -11946,7 +13103,7 @@
                     "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
                     "dev": true,
                     "requires": {
-                        "once": "1.4.0"
+                        "once": "^1.4.0"
                     }
                 },
                 "once": {
@@ -11955,7 +13112,7 @@
                     "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                     "dev": true,
                     "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                     }
                 }
             }
@@ -11966,8 +13123,8 @@
             "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
             "dev": true,
             "requires": {
-                "os-tmpdir": "1.0.2",
-                "rimraf": "2.2.8"
+                "os-tmpdir": "^1.0.0",
+                "rimraf": "~2.2.6"
             },
             "dependencies": {
                 "rimraf": {
@@ -11984,8 +13141,8 @@
             "integrity": "sha1-C2Rng43Xf79/YqDJPah5cy/9qTI=",
             "dev": true,
             "requires": {
-                "graceful-fs": "2.0.3",
-                "tempfile": "0.1.3"
+                "graceful-fs": "~2.0.0",
+                "tempfile": "~0.1.2"
             },
             "dependencies": {
                 "graceful-fs": {
@@ -12002,7 +13159,7 @@
             "integrity": "sha1-fWtxAEcznTn4RzJ6BW2t8YMQMBA=",
             "dev": true,
             "requires": {
-                "uuid": "1.4.2"
+                "uuid": "~1.4.0"
             },
             "dependencies": {
                 "uuid": {
@@ -12020,7 +13177,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "execa": "0.7.0"
+                "execa": "^0.7.0"
             }
         },
         "ternary-stream": {
@@ -12029,10 +13186,10 @@
             "integrity": "sha1-Bk5Im0tb9gumpre8fy9cJ07Pgmk=",
             "dev": true,
             "requires": {
-                "duplexify": "3.5.1",
-                "fork-stream": "0.0.4",
-                "merge-stream": "1.0.1",
-                "through2": "2.0.3"
+                "duplexify": "^3.5.0",
+                "fork-stream": "^0.0.4",
+                "merge-stream": "^1.0.0",
+                "through2": "^2.0.1"
             }
         },
         "test-value": {
@@ -12041,8 +13198,8 @@
             "integrity": "sha1-Edpv9nDzRxpztiXKTz/c97t0gpE=",
             "dev": true,
             "requires": {
-                "array-back": "1.0.4",
-                "typical": "2.6.1"
+                "array-back": "^1.0.3",
+                "typical": "^2.6.0"
             }
         },
         "text-encoding": {
@@ -12069,8 +13226,8 @@
             "integrity": "sha1-OORBT8ZJd9h6/apy+sttKfgve1s=",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "object-path": "0.9.2"
+                "chalk": "^1.1.1",
+                "object-path": "^0.9.0"
             }
         },
         "thenify": {
@@ -12079,7 +13236,7 @@
             "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
             "dev": true,
             "requires": {
-                "any-promise": "1.3.0"
+                "any-promise": "^1.0.0"
             }
         },
         "thenify-all": {
@@ -12088,7 +13245,7 @@
             "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
             "dev": true,
             "requires": {
-                "thenify": "3.3.0"
+                "thenify": ">= 3.1.0 < 4"
             }
         },
         "through": {
@@ -12103,8 +13260,8 @@
             "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.3",
-                "xtend": "4.0.1"
+                "readable-stream": "^2.1.5",
+                "xtend": "~4.0.1"
             }
         },
         "through2-filter": {
@@ -12113,8 +13270,8 @@
             "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
             "dev": true,
             "requires": {
-                "through2": "2.0.3",
-                "xtend": "4.0.1"
+                "through2": "~2.0.0",
+                "xtend": "~4.0.0"
             }
         },
         "thunks": {
@@ -12129,7 +13286,7 @@
             "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
             "dev": true,
             "requires": {
-                "os-homedir": "1.0.2"
+                "os-homedir": "^1.0.0"
             }
         },
         "time-stamp": {
@@ -12150,7 +13307,7 @@
             "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
             "dev": true,
             "requires": {
-                "os-tmpdir": "1.0.2"
+                "os-tmpdir": "~1.0.1"
             }
         },
         "to-absolute-glob": {
@@ -12159,7 +13316,7 @@
             "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
             "dev": true,
             "requires": {
-                "extend-shallow": "2.0.1"
+                "extend-shallow": "^2.0.1"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -12168,7 +13325,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -12185,13 +13342,76 @@
             "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
             "dev": true
         },
+        "to-object-path": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+            "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+            "dev": true,
+            "requires": {
+                "kind-of": "^3.0.2"
+            }
+        },
+        "to-regex": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+            "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+            "dev": true,
+            "requires": {
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "regex-not": "^1.0.2",
+                "safe-regex": "^1.1.0"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+                    "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+                    "dev": true,
+                    "requires": {
+                        "assign-symbols": "^1.0.0",
+                        "is-extendable": "^1.0.1"
+                    }
+                },
+                "is-extendable": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+                    "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                    "dev": true,
+                    "requires": {
+                        "is-plain-object": "^2.0.4"
+                    }
+                }
+            }
+        },
+        "to-regex-range": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+            "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+            "dev": true,
+            "requires": {
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1"
+            },
+            "dependencies": {
+                "is-number": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^3.0.2"
+                    }
+                }
+            }
+        },
         "tough-cookie": {
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
             "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
             "dev": true,
             "requires": {
-                "punycode": "1.4.1"
+                "punycode": "^1.4.1"
             }
         },
         "trim-newlines": {
@@ -12212,7 +13432,7 @@
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
             "dev": true,
             "requires": {
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "^5.0.1"
             }
         },
         "tweetnacl": {
@@ -12228,7 +13448,7 @@
             "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
             "dev": true,
             "requires": {
-                "prelude-ls": "1.1.2"
+                "prelude-ls": "~1.1.2"
             }
         },
         "type-detect": {
@@ -12244,7 +13464,7 @@
             "dev": true,
             "requires": {
                 "media-typer": "0.3.0",
-                "mime-types": "2.1.17"
+                "mime-types": "~2.1.15"
             }
         },
         "typedarray": {
@@ -12271,8 +13491,8 @@
             "integrity": "sha512-L98DlTshoPGnZGF8pr3MoE+CCo6n9joktHNHMPkckeBV8xTVc4CWtC0kGGhQsIvnX2Ug4nXFTAeE7SpTrPX2tg==",
             "dev": true,
             "requires": {
-                "commander": "2.12.2",
-                "source-map": "0.6.1"
+                "commander": "~2.12.1",
+                "source-map": "~0.6.1"
             },
             "dependencies": {
                 "source-map": {
@@ -12307,8 +13527,49 @@
             "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
             "dev": true,
             "requires": {
-                "sprintf-js": "1.0.3",
-                "util-deprecate": "1.0.2"
+                "sprintf-js": "^1.0.3",
+                "util-deprecate": "^1.0.2"
+            }
+        },
+        "union-value": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+            "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+            "dev": true,
+            "requires": {
+                "arr-union": "^3.1.0",
+                "get-value": "^2.0.6",
+                "is-extendable": "^0.1.1",
+                "set-value": "^0.4.3"
+            },
+            "dependencies": {
+                "arr-union": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+                    "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+                    "dev": true
+                },
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                },
+                "set-value": {
+                    "version": "0.4.3",
+                    "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+                    "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+                    "dev": true,
+                    "requires": {
+                        "extend-shallow": "^2.0.1",
+                        "is-extendable": "^0.1.1",
+                        "is-plain-object": "^2.0.1",
+                        "to-object-path": "^0.3.0"
+                    }
+                }
             }
         },
         "unique-stream": {
@@ -12324,7 +13585,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "crypto-random-string": "1.0.0"
+                "crypto-random-string": "^1.0.0"
             }
         },
         "universalify": {
@@ -12339,13 +13600,59 @@
             "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
             "dev": true
         },
+        "unset-value": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+            "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+            "dev": true,
+            "requires": {
+                "has-value": "^0.3.1",
+                "isobject": "^3.0.0"
+            },
+            "dependencies": {
+                "has-value": {
+                    "version": "0.3.1",
+                    "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+                    "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+                    "dev": true,
+                    "requires": {
+                        "get-value": "^2.0.3",
+                        "has-values": "^0.1.4",
+                        "isobject": "^2.0.0"
+                    },
+                    "dependencies": {
+                        "isobject": {
+                            "version": "2.1.0",
+                            "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                            "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+                            "dev": true,
+                            "requires": {
+                                "isarray": "1.0.0"
+                            }
+                        }
+                    }
+                },
+                "has-values": {
+                    "version": "0.1.4",
+                    "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+                    "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+                    "dev": true
+                },
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
+                }
+            }
+        },
         "untildify": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
             "integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
             "dev": true,
             "requires": {
-                "os-homedir": "1.0.2"
+                "os-homedir": "^1.0.0"
             }
         },
         "unzip-response": {
@@ -12360,14 +13667,14 @@
             "integrity": "sha1-j5LFFUgr1oMbfJMBPnD4dVLHz1o=",
             "dev": true,
             "requires": {
-                "boxen": "0.6.0",
-                "chalk": "1.1.3",
-                "configstore": "2.1.0",
-                "is-npm": "1.0.0",
-                "latest-version": "2.0.0",
-                "lazy-req": "1.1.0",
-                "semver-diff": "2.1.0",
-                "xdg-basedir": "2.0.0"
+                "boxen": "^0.6.0",
+                "chalk": "^1.0.0",
+                "configstore": "^2.0.0",
+                "is-npm": "^1.0.0",
+                "latest-version": "^2.0.0",
+                "lazy-req": "^1.1.0",
+                "semver-diff": "^2.0.0",
+                "xdg-basedir": "^2.0.0"
             }
         },
         "upper-case": {
@@ -12382,14 +13689,26 @@
             "integrity": "sha512-Qs2odXn0hST5VSPVjpi73CMqtbAoanahaqWBujGU+IyMrMqpWcIhDewxQRhCkmqYxuyvICDcSuLdv2O7ncWBGw==",
             "dev": true
         },
+        "urix": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+            "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+            "dev": true
+        },
         "url-parse-lax": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
             "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
             "dev": true,
             "requires": {
-                "prepend-http": "1.0.4"
+                "prepend-http": "^1.0.1"
             }
+        },
+        "use": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+            "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+            "dev": true
         },
         "user-home": {
             "version": "1.1.1",
@@ -12428,7 +13747,7 @@
             "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
             "dev": true,
             "requires": {
-                "user-home": "1.1.1"
+                "user-home": "^1.1.1"
             }
         },
         "vali-date": {
@@ -12443,8 +13762,8 @@
             "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
             "dev": true,
             "requires": {
-                "spdx-correct": "1.0.2",
-                "spdx-expression-parse": "1.0.4"
+                "spdx-correct": "~1.0.0",
+                "spdx-expression-parse": "~1.0.0"
             }
         },
         "vargs": {
@@ -12465,9 +13784,9 @@
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0",
+                "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
+                "extsprintf": "^1.2.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -12484,8 +13803,8 @@
             "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
             "dev": true,
             "requires": {
-                "clone": "1.0.3",
-                "clone-stats": "0.0.1",
+                "clone": "^1.0.0",
+                "clone-stats": "^0.0.1",
                 "replace-ext": "0.0.1"
             }
         },
@@ -12495,12 +13814,12 @@
             "integrity": "sha1-p+v1/779obfRjRQPyweyI++2dRo=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1",
-                "strip-bom": "2.0.0",
-                "strip-bom-stream": "2.0.0",
-                "vinyl": "1.2.0"
+                "graceful-fs": "^4.1.2",
+                "pify": "^2.3.0",
+                "pinkie-promise": "^2.0.0",
+                "strip-bom": "^2.0.0",
+                "strip-bom-stream": "^2.0.0",
+                "vinyl": "^1.1.0"
             },
             "dependencies": {
                 "first-chunk-stream": {
@@ -12509,7 +13828,7 @@
                     "integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "2.3.3"
+                        "readable-stream": "^2.0.2"
                     }
                 },
                 "strip-bom-stream": {
@@ -12518,8 +13837,8 @@
                     "integrity": "sha1-+H217yYT9paKpUWr/h7HKLaoKco=",
                     "dev": true,
                     "requires": {
-                        "first-chunk-stream": "2.0.0",
-                        "strip-bom": "2.0.0"
+                        "first-chunk-stream": "^2.0.0",
+                        "strip-bom": "^2.0.0"
                     }
                 },
                 "vinyl": {
@@ -12528,8 +13847,8 @@
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.3",
-                        "clone-stats": "0.0.1",
+                        "clone": "^1.0.0",
+                        "clone-stats": "^0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
@@ -12541,14 +13860,14 @@
             "integrity": "sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=",
             "dev": true,
             "requires": {
-                "defaults": "1.0.3",
-                "glob-stream": "3.1.18",
-                "glob-watcher": "0.0.6",
-                "graceful-fs": "3.0.11",
-                "mkdirp": "0.5.1",
-                "strip-bom": "1.0.0",
-                "through2": "0.6.5",
-                "vinyl": "0.4.6"
+                "defaults": "^1.0.0",
+                "glob-stream": "^3.1.5",
+                "glob-watcher": "^0.0.6",
+                "graceful-fs": "^3.0.0",
+                "mkdirp": "^0.5.0",
+                "strip-bom": "^1.0.0",
+                "through2": "^0.6.1",
+                "vinyl": "^0.4.0"
             },
             "dependencies": {
                 "clone": {
@@ -12563,7 +13882,7 @@
                     "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
                     "dev": true,
                     "requires": {
-                        "natives": "1.1.0"
+                        "natives": "^1.1.0"
                     }
                 },
                 "isarray": {
@@ -12593,10 +13912,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -12611,8 +13930,8 @@
                     "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
                     "dev": true,
                     "requires": {
-                        "first-chunk-stream": "1.0.0",
-                        "is-utf8": "0.2.1"
+                        "first-chunk-stream": "^1.0.0",
+                        "is-utf8": "^0.2.0"
                     }
                 },
                 "through2": {
@@ -12621,8 +13940,8 @@
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "4.0.1"
+                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                        "xtend": ">=4.0.0 <4.1.0-0"
                     }
                 },
                 "vinyl": {
@@ -12631,8 +13950,8 @@
                     "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
                     "dev": true,
                     "requires": {
-                        "clone": "0.2.0",
-                        "clone-stats": "0.0.1"
+                        "clone": "^0.2.0",
+                        "clone-stats": "^0.0.1"
                     }
                 }
             }
@@ -12643,7 +13962,7 @@
             "integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
             "dev": true,
             "requires": {
-                "source-map": "0.5.7"
+                "source-map": "^0.5.1"
             }
         },
         "walkdir": {
@@ -12658,7 +13977,7 @@
             "integrity": "sha1-1pe5nx9ZUS3ydRvkJ2nBWAtYAf4=",
             "dev": true,
             "requires": {
-                "minimalistic-assert": "1.0.0"
+                "minimalistic-assert": "^1.0.0"
             }
         },
         "wct-local": {
@@ -12668,19 +13987,19 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "@types/chalk": "0.4.31",
-                "@types/express": "4.0.39",
-                "@types/freeport": "1.0.21",
-                "@types/launchpad": "0.6.0",
-                "@types/node": "6.0.92",
-                "@types/which": "1.0.28",
-                "chalk": "1.1.3",
-                "cleankill": "2.0.0",
-                "freeport": "1.0.5",
-                "launchpad": "0.6.0",
-                "promisify-node": "0.4.0",
-                "selenium-standalone": "5.11.2",
-                "which": "1.3.0"
+                "@types/chalk": "^0.4.28",
+                "@types/express": "^4.0.30",
+                "@types/freeport": "^1.0.19",
+                "@types/launchpad": "^0.6.0",
+                "@types/node": "^6.0.31",
+                "@types/which": "^1.0.27",
+                "chalk": "^1.1.1",
+                "cleankill": "^2.0.0",
+                "freeport": "^1.0.4",
+                "launchpad": "^0.6.0",
+                "promisify-node": "^0.4.0",
+                "selenium-standalone": "^5.8.0",
+                "which": "^1.0.8"
             },
             "dependencies": {
                 "@types/node": {
@@ -12699,13 +14018,13 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "chalk": "1.1.3",
-                "cleankill": "2.0.0",
-                "lodash": "3.10.1",
-                "request": "2.81.0",
-                "sauce-connect-launcher": "1.2.3",
-                "temp": "0.8.3",
-                "uuid": "2.0.3"
+                "chalk": "^1.1.1",
+                "cleankill": "^2.0.0",
+                "lodash": "^3.0.1",
+                "request": "^2.53.0",
+                "sauce-connect-launcher": "^1.0.0",
+                "temp": "^0.8.1",
+                "uuid": "^2.0.1"
             },
             "dependencies": {
                 "uuid": {
@@ -12726,7 +14045,7 @@
                 "archiver": "1.3.0",
                 "async": "2.0.1",
                 "lodash": "4.16.2",
-                "mkdirp": "0.5.1",
+                "mkdirp": "^0.5.1",
                 "q": "1.4.1",
                 "request": "2.79.0",
                 "underscore.string": "3.3.4",
@@ -12739,7 +14058,7 @@
                     "integrity": "sha1-twnMAoCpw28J9FNr6CPIOKkEniU=",
                     "dev": true,
                     "requires": {
-                        "lodash": "4.16.2"
+                        "lodash": "^4.8.0"
                     }
                 },
                 "caseless": {
@@ -12754,10 +14073,10 @@
                     "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "commander": "2.12.2",
-                        "is-my-json-valid": "2.16.1",
-                        "pinkie-promise": "2.0.1"
+                        "chalk": "^1.1.1",
+                        "commander": "^2.9.0",
+                        "is-my-json-valid": "^2.12.4",
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "lodash": {
@@ -12799,26 +14118,26 @@
                     "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
                     "dev": true,
                     "requires": {
-                        "aws-sign2": "0.6.0",
-                        "aws4": "1.6.0",
-                        "caseless": "0.11.0",
-                        "combined-stream": "1.0.5",
-                        "extend": "3.0.1",
-                        "forever-agent": "0.6.1",
-                        "form-data": "2.1.4",
-                        "har-validator": "2.0.6",
-                        "hawk": "3.1.3",
-                        "http-signature": "1.1.1",
-                        "is-typedarray": "1.0.0",
-                        "isstream": "0.1.2",
-                        "json-stringify-safe": "5.0.1",
-                        "mime-types": "2.1.17",
-                        "oauth-sign": "0.8.2",
-                        "qs": "6.3.2",
-                        "stringstream": "0.0.5",
-                        "tough-cookie": "2.3.3",
-                        "tunnel-agent": "0.4.3",
-                        "uuid": "3.1.0"
+                        "aws-sign2": "~0.6.0",
+                        "aws4": "^1.2.1",
+                        "caseless": "~0.11.0",
+                        "combined-stream": "~1.0.5",
+                        "extend": "~3.0.0",
+                        "forever-agent": "~0.6.1",
+                        "form-data": "~2.1.1",
+                        "har-validator": "~2.0.6",
+                        "hawk": "~3.1.3",
+                        "http-signature": "~1.1.0",
+                        "is-typedarray": "~1.0.0",
+                        "isstream": "~0.1.2",
+                        "json-stringify-safe": "~5.0.1",
+                        "mime-types": "~2.1.7",
+                        "oauth-sign": "~0.8.1",
+                        "qs": "~6.3.0",
+                        "stringstream": "~0.0.4",
+                        "tough-cookie": "~2.3.0",
+                        "tunnel-agent": "~0.4.1",
+                        "uuid": "^3.0.0"
                     }
                 },
                 "tunnel-agent": {
@@ -12835,36 +14154,36 @@
             "integrity": "sha512-ke9sY2ayW4Ck28vty7aSGpsrUWwl8FqWY6o6ryqsbcIH3AQZDZTdpxo9xT8HSIwj+0C9ooQ4gnBI5VhHyA9+ZA==",
             "dev": true,
             "requires": {
-                "@polymer/sinonjs": "1.17.1",
-                "@polymer/test-fixture": "0.0.3",
-                "@webcomponents/webcomponentsjs": "1.0.19",
-                "accessibility-developer-tools": "2.12.0",
-                "async": "2.6.0",
-                "body-parser": "1.18.2",
-                "chai": "4.1.2",
-                "chalk": "1.1.3",
-                "cleankill": "2.0.0",
-                "express": "4.16.2",
-                "findup-sync": "1.0.0",
-                "glob": "7.1.2",
-                "lodash": "3.10.1",
-                "mocha": "3.5.3",
-                "multer": "1.3.0",
-                "nomnom": "1.8.1",
-                "polyserve": "0.23.0",
-                "promisify-node": "0.4.0",
-                "resolve": "1.5.0",
-                "semver": "5.4.1",
-                "send": "0.11.1",
-                "server-destroy": "1.0.1",
-                "sinon": "2.4.1",
-                "sinon-chai": "2.14.0",
-                "socket.io": "2.0.4",
-                "stacky": "1.3.1",
-                "update-notifier": "2.3.0",
-                "wct-local": "2.0.16",
-                "wct-sauce": "2.0.0-pre.3",
-                "wd": "1.4.1"
+                "@polymer/sinonjs": "^1.14.1",
+                "@polymer/test-fixture": "^0.0.3",
+                "@webcomponents/webcomponentsjs": "^1.0.7",
+                "accessibility-developer-tools": "^2.12.0",
+                "async": "^2.4.1",
+                "body-parser": "^1.17.2",
+                "chai": "^4.0.2",
+                "chalk": "^1.1.3",
+                "cleankill": "^2.0.0",
+                "express": "^4.15.3",
+                "findup-sync": "^1.0.0",
+                "glob": "^7.1.2",
+                "lodash": "^3.10.1",
+                "mocha": "^3.4.2",
+                "multer": "^1.3.0",
+                "nomnom": "^1.8.1",
+                "polyserve": "^0.23.0",
+                "promisify-node": "^0.4.0",
+                "resolve": "^1.3.3",
+                "semver": "^5.3.0",
+                "send": "^0.11.1",
+                "server-destroy": "^1.0.1",
+                "sinon": "^2.3.5",
+                "sinon-chai": "^2.10.0",
+                "socket.io": "^2.0.3",
+                "stacky": "^1.3.1",
+                "update-notifier": "^2.2.0",
+                "wct-local": "^2.0.16",
+                "wct-sauce": "^2.0.0-pre.2",
+                "wd": "^1.2.0"
             },
             "dependencies": {
                 "after": {
@@ -12880,7 +14199,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "string-width": "2.1.1"
+                        "string-width": "^2.0.0"
                     }
                 },
                 "ansi-regex": {
@@ -12895,7 +14214,7 @@
                     "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "1.9.1"
+                        "color-convert": "^1.9.0"
                     }
                 },
                 "async": {
@@ -12904,7 +14223,7 @@
                     "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
                     "dev": true,
                     "requires": {
-                        "lodash": "4.17.4"
+                        "lodash": "^4.14.0"
                     },
                     "dependencies": {
                         "lodash": {
@@ -12928,13 +14247,13 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "ansi-align": "2.0.0",
-                        "camelcase": "4.1.0",
-                        "chalk": "2.3.0",
-                        "cli-boxes": "1.0.0",
-                        "string-width": "2.1.1",
-                        "term-size": "1.2.0",
-                        "widest-line": "1.0.0"
+                        "ansi-align": "^2.0.0",
+                        "camelcase": "^4.0.0",
+                        "chalk": "^2.0.1",
+                        "cli-boxes": "^1.0.0",
+                        "string-width": "^2.0.0",
+                        "term-size": "^1.2.0",
+                        "widest-line": "^1.0.0"
                     },
                     "dependencies": {
                         "chalk": {
@@ -12944,9 +14263,9 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "ansi-styles": "3.2.0",
-                                "escape-string-regexp": "1.0.5",
-                                "supports-color": "4.5.0"
+                                "ansi-styles": "^3.1.0",
+                                "escape-string-regexp": "^1.0.5",
+                                "supports-color": "^4.0.0"
                             }
                         }
                     }
@@ -12971,12 +14290,12 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "dot-prop": "4.2.0",
-                        "graceful-fs": "4.1.11",
-                        "make-dir": "1.1.0",
-                        "unique-string": "1.0.0",
-                        "write-file-atomic": "2.3.0",
-                        "xdg-basedir": "3.0.0"
+                        "dot-prop": "^4.1.0",
+                        "graceful-fs": "^4.1.2",
+                        "make-dir": "^1.0.0",
+                        "unique-string": "^1.0.0",
+                        "write-file-atomic": "^2.0.0",
+                        "xdg-basedir": "^3.0.0"
                     }
                 },
                 "debug": {
@@ -12995,7 +14314,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "is-obj": "1.0.1"
+                        "is-obj": "^1.0.0"
                     }
                 },
                 "ee-first": {
@@ -13013,10 +14332,10 @@
                         "accepts": "1.3.3",
                         "base64id": "1.0.0",
                         "cookie": "0.3.1",
-                        "debug": "2.6.9",
-                        "engine.io-parser": "2.1.1",
-                        "uws": "0.14.5",
-                        "ws": "3.3.2"
+                        "debug": "~2.6.9",
+                        "engine.io-parser": "~2.1.0",
+                        "uws": "~0.14.4",
+                        "ws": "~3.3.1"
                     },
                     "dependencies": {
                         "accepts": {
@@ -13025,7 +14344,7 @@
                             "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
                             "dev": true,
                             "requires": {
-                                "mime-types": "2.1.17",
+                                "mime-types": "~2.1.11",
                                 "negotiator": "0.6.1"
                             }
                         }
@@ -13039,14 +14358,14 @@
                     "requires": {
                         "component-emitter": "1.2.1",
                         "component-inherit": "0.0.3",
-                        "debug": "2.6.9",
-                        "engine.io-parser": "2.1.1",
+                        "debug": "~2.6.9",
+                        "engine.io-parser": "~2.1.1",
                         "has-cors": "1.1.0",
                         "indexof": "0.0.1",
                         "parseqs": "0.0.5",
                         "parseuri": "0.0.5",
-                        "ws": "3.3.2",
-                        "xmlhttprequest-ssl": "1.5.4",
+                        "ws": "~3.3.1",
+                        "xmlhttprequest-ssl": "~1.5.4",
                         "yeast": "0.1.2"
                     }
                 },
@@ -13060,7 +14379,7 @@
                         "arraybuffer.slice": "0.0.6",
                         "base64-arraybuffer": "0.1.5",
                         "blob": "0.0.4",
-                        "has-binary2": "1.0.2"
+                        "has-binary2": "~1.0.2"
                     }
                 },
                 "express": {
@@ -13069,36 +14388,36 @@
                     "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
                     "dev": true,
                     "requires": {
-                        "accepts": "1.3.4",
+                        "accepts": "~1.3.4",
                         "array-flatten": "1.1.1",
                         "body-parser": "1.18.2",
                         "content-disposition": "0.5.2",
-                        "content-type": "1.0.4",
+                        "content-type": "~1.0.4",
                         "cookie": "0.3.1",
                         "cookie-signature": "1.0.6",
                         "debug": "2.6.9",
-                        "depd": "1.1.1",
-                        "encodeurl": "1.0.1",
-                        "escape-html": "1.0.3",
-                        "etag": "1.8.1",
+                        "depd": "~1.1.1",
+                        "encodeurl": "~1.0.1",
+                        "escape-html": "~1.0.3",
+                        "etag": "~1.8.1",
                         "finalhandler": "1.1.0",
                         "fresh": "0.5.2",
                         "merge-descriptors": "1.0.1",
-                        "methods": "1.1.2",
-                        "on-finished": "2.3.0",
-                        "parseurl": "1.3.2",
+                        "methods": "~1.1.2",
+                        "on-finished": "~2.3.0",
+                        "parseurl": "~1.3.2",
                         "path-to-regexp": "0.1.7",
-                        "proxy-addr": "2.0.2",
+                        "proxy-addr": "~2.0.2",
                         "qs": "6.5.1",
-                        "range-parser": "1.2.0",
+                        "range-parser": "~1.2.0",
                         "safe-buffer": "5.1.1",
                         "send": "0.16.1",
                         "serve-static": "1.13.1",
                         "setprototypeof": "1.1.0",
-                        "statuses": "1.3.1",
-                        "type-is": "1.6.15",
+                        "statuses": "~1.3.1",
+                        "type-is": "~1.6.15",
                         "utils-merge": "1.0.1",
-                        "vary": "1.1.2"
+                        "vary": "~1.1.2"
                     },
                     "dependencies": {
                         "send": {
@@ -13108,18 +14427,18 @@
                             "dev": true,
                             "requires": {
                                 "debug": "2.6.9",
-                                "depd": "1.1.1",
-                                "destroy": "1.0.4",
-                                "encodeurl": "1.0.1",
-                                "escape-html": "1.0.3",
-                                "etag": "1.8.1",
+                                "depd": "~1.1.1",
+                                "destroy": "~1.0.4",
+                                "encodeurl": "~1.0.1",
+                                "escape-html": "~1.0.3",
+                                "etag": "~1.8.1",
                                 "fresh": "0.5.2",
-                                "http-errors": "1.6.2",
+                                "http-errors": "~1.6.2",
                                 "mime": "1.4.1",
                                 "ms": "2.0.0",
-                                "on-finished": "2.3.0",
-                                "range-parser": "1.2.0",
-                                "statuses": "1.3.1"
+                                "on-finished": "~2.3.0",
+                                "range-parser": "~1.2.0",
+                                "statuses": "~1.3.1"
                             }
                         }
                     }
@@ -13131,12 +14450,12 @@
                     "dev": true,
                     "requires": {
                         "debug": "2.6.9",
-                        "encodeurl": "1.0.1",
-                        "escape-html": "1.0.3",
-                        "on-finished": "2.3.0",
-                        "parseurl": "1.3.2",
-                        "statuses": "1.3.1",
-                        "unpipe": "1.0.0"
+                        "encodeurl": "~1.0.1",
+                        "escape-html": "~1.0.3",
+                        "on-finished": "~2.3.0",
+                        "parseurl": "~1.3.2",
+                        "statuses": "~1.3.1",
+                        "unpipe": "~1.0.0"
                     }
                 },
                 "findup-sync": {
@@ -13145,10 +14464,10 @@
                     "integrity": "sha1-b35LV7buOkA3tEFOrt6j9Y9x4Ow=",
                     "dev": true,
                     "requires": {
-                        "detect-file": "0.1.0",
-                        "is-glob": "2.0.1",
-                        "micromatch": "2.3.11",
-                        "resolve-dir": "0.1.1"
+                        "detect-file": "^0.1.0",
+                        "is-glob": "^2.0.1",
+                        "micromatch": "^2.3.7",
+                        "resolve-dir": "^0.1.0"
                     }
                 },
                 "fresh": {
@@ -13163,12 +14482,12 @@
                     "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.3.3",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "got": {
@@ -13178,17 +14497,17 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "create-error-class": "3.0.2",
-                        "duplexer3": "0.1.4",
-                        "get-stream": "3.0.0",
-                        "is-redirect": "1.0.0",
-                        "is-retry-allowed": "1.1.0",
-                        "is-stream": "1.1.0",
-                        "lowercase-keys": "1.0.0",
-                        "safe-buffer": "5.1.1",
-                        "timed-out": "4.0.1",
-                        "unzip-response": "2.0.1",
-                        "url-parse-lax": "1.0.0"
+                        "create-error-class": "^3.0.0",
+                        "duplexer3": "^0.1.4",
+                        "get-stream": "^3.0.0",
+                        "is-redirect": "^1.0.0",
+                        "is-retry-allowed": "^1.0.0",
+                        "is-stream": "^1.0.0",
+                        "lowercase-keys": "^1.0.0",
+                        "safe-buffer": "^5.0.1",
+                        "timed-out": "^4.0.0",
+                        "unzip-response": "^2.0.1",
+                        "url-parse-lax": "^1.0.0"
                     }
                 },
                 "has-flag": {
@@ -13206,7 +14525,7 @@
                         "depd": "1.1.1",
                         "inherits": "2.0.3",
                         "setprototypeof": "1.0.3",
-                        "statuses": "1.3.1"
+                        "statuses": ">= 1.3.1 < 2"
                     },
                     "dependencies": {
                         "setprototypeof": {
@@ -13236,7 +14555,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "package-json": "4.0.1"
+                        "package-json": "^4.0.0"
                     }
                 },
                 "mime": {
@@ -13258,10 +14577,10 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "got": "6.7.1",
-                        "registry-auth-token": "3.3.1",
-                        "registry-url": "3.1.0",
-                        "semver": "5.4.1"
+                        "got": "^6.7.1",
+                        "registry-auth-token": "^3.0.1",
+                        "registry-url": "^3.0.3",
+                        "semver": "^5.1.0"
                     }
                 },
                 "path-to-regexp": {
@@ -13282,16 +14601,16 @@
                     "integrity": "sha1-G+q/1C+eJwn5kCivMHisErRwktU=",
                     "dev": true,
                     "requires": {
-                        "debug": "2.1.3",
-                        "depd": "1.0.1",
+                        "debug": "~2.1.1",
+                        "depd": "~1.0.0",
                         "destroy": "1.0.3",
                         "escape-html": "1.0.1",
-                        "etag": "1.5.1",
+                        "etag": "~1.5.1",
                         "fresh": "0.2.4",
                         "mime": "1.2.11",
                         "ms": "0.7.0",
-                        "on-finished": "2.2.1",
-                        "range-parser": "1.0.3"
+                        "on-finished": "~2.2.0",
+                        "range-parser": "~1.0.2"
                     },
                     "dependencies": {
                         "debug": {
@@ -13371,9 +14690,9 @@
                     "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
                     "dev": true,
                     "requires": {
-                        "encodeurl": "1.0.1",
-                        "escape-html": "1.0.3",
-                        "parseurl": "1.3.2",
+                        "encodeurl": "~1.0.1",
+                        "escape-html": "~1.0.3",
+                        "parseurl": "~1.3.2",
                         "send": "0.16.1"
                     },
                     "dependencies": {
@@ -13384,18 +14703,18 @@
                             "dev": true,
                             "requires": {
                                 "debug": "2.6.9",
-                                "depd": "1.1.1",
-                                "destroy": "1.0.4",
-                                "encodeurl": "1.0.1",
-                                "escape-html": "1.0.3",
-                                "etag": "1.8.1",
+                                "depd": "~1.1.1",
+                                "destroy": "~1.0.4",
+                                "encodeurl": "~1.0.1",
+                                "escape-html": "~1.0.3",
+                                "etag": "~1.8.1",
                                 "fresh": "0.5.2",
-                                "http-errors": "1.6.2",
+                                "http-errors": "~1.6.2",
                                 "mime": "1.4.1",
                                 "ms": "2.0.0",
-                                "on-finished": "2.3.0",
-                                "range-parser": "1.2.0",
-                                "statuses": "1.3.1"
+                                "on-finished": "~2.3.0",
+                                "range-parser": "~1.2.0",
+                                "statuses": "~1.3.1"
                             }
                         }
                     }
@@ -13412,11 +14731,11 @@
                     "integrity": "sha1-waRZDO/4fs8TxyZS8Eb3FrKeYBQ=",
                     "dev": true,
                     "requires": {
-                        "debug": "2.6.9",
-                        "engine.io": "3.1.4",
-                        "socket.io-adapter": "1.1.1",
+                        "debug": "~2.6.6",
+                        "engine.io": "~3.1.0",
+                        "socket.io-adapter": "~1.1.0",
                         "socket.io-client": "2.0.4",
-                        "socket.io-parser": "3.1.2"
+                        "socket.io-parser": "~3.1.1"
                     }
                 },
                 "socket.io-adapter": {
@@ -13435,14 +14754,14 @@
                         "base64-arraybuffer": "0.1.5",
                         "component-bind": "1.0.0",
                         "component-emitter": "1.2.1",
-                        "debug": "2.6.9",
-                        "engine.io-client": "3.1.4",
+                        "debug": "~2.6.4",
+                        "engine.io-client": "~3.1.0",
                         "has-cors": "1.1.0",
                         "indexof": "0.0.1",
                         "object-component": "0.0.3",
                         "parseqs": "0.0.5",
                         "parseuri": "0.0.5",
-                        "socket.io-parser": "3.1.2",
+                        "socket.io-parser": "~3.1.1",
                         "to-array": "0.1.4"
                     }
                 },
@@ -13453,8 +14772,8 @@
                     "dev": true,
                     "requires": {
                         "component-emitter": "1.2.1",
-                        "debug": "2.6.9",
-                        "has-binary2": "1.0.2",
+                        "debug": "~2.6.4",
+                        "has-binary2": "~1.0.2",
                         "isarray": "2.0.1"
                     }
                 },
@@ -13464,8 +14783,8 @@
                     "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
                     "dev": true,
                     "requires": {
-                        "is-fullwidth-code-point": "2.0.0",
-                        "strip-ansi": "4.0.0"
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -13474,7 +14793,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "3.0.0"
+                        "ansi-regex": "^3.0.0"
                     }
                 },
                 "supports-color": {
@@ -13483,7 +14802,7 @@
                     "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "2.0.0"
+                        "has-flag": "^2.0.0"
                     }
                 },
                 "timed-out": {
@@ -13513,15 +14832,15 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "boxen": "1.2.2",
-                        "chalk": "2.3.0",
-                        "configstore": "3.1.1",
-                        "import-lazy": "2.1.0",
-                        "is-installed-globally": "0.1.0",
-                        "is-npm": "1.0.0",
-                        "latest-version": "3.1.0",
-                        "semver-diff": "2.1.0",
-                        "xdg-basedir": "3.0.0"
+                        "boxen": "^1.2.1",
+                        "chalk": "^2.0.1",
+                        "configstore": "^3.0.0",
+                        "import-lazy": "^2.1.0",
+                        "is-installed-globally": "^0.1.0",
+                        "is-npm": "^1.0.0",
+                        "latest-version": "^3.0.0",
+                        "semver-diff": "^2.0.0",
+                        "xdg-basedir": "^3.0.0"
                     },
                     "dependencies": {
                         "chalk": {
@@ -13531,9 +14850,9 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "ansi-styles": "3.2.0",
-                                "escape-string-regexp": "1.0.5",
-                                "supports-color": "4.5.0"
+                                "ansi-styles": "^3.1.0",
+                                "escape-string-regexp": "^1.0.5",
+                                "supports-color": "^4.0.0"
                             }
                         }
                     }
@@ -13551,9 +14870,9 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "imurmurhash": "0.1.4",
-                        "signal-exit": "3.0.2"
+                        "graceful-fs": "^4.1.11",
+                        "imurmurhash": "^0.1.4",
+                        "signal-exit": "^3.0.2"
                     }
                 },
                 "ws": {
@@ -13562,9 +14881,9 @@
                     "integrity": "sha512-t+WGpsNxhMR4v6EClXS8r8km5ZljKJzyGhJf7goJz9k5Ye3+b5Bvno5rjqPuIBn5mnn5GBb7o8IrIWHxX1qOLQ==",
                     "dev": true,
                     "requires": {
-                        "async-limiter": "1.0.0",
-                        "safe-buffer": "5.1.1",
-                        "ultron": "1.1.1"
+                        "async-limiter": "~1.0.0",
+                        "safe-buffer": "~5.1.0",
+                        "ultron": "~1.1.0"
                     }
                 },
                 "xdg-basedir": {
@@ -13587,9 +14906,9 @@
             "integrity": "sha1-/viqIjkh97QLu71MPtQwL2/QqBM=",
             "dev": true,
             "requires": {
-                "express": "2.5.11",
-                "nopt": "3.0.6",
-                "underscore": "1.7.0"
+                "express": "2.5.x",
+                "nopt": "3.0.x",
+                "underscore": "1.7.x"
             }
         },
         "which": {
@@ -13598,7 +14917,7 @@
             "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
             "dev": true,
             "requires": {
-                "isexe": "2.0.0"
+                "isexe": "^2.0.0"
             }
         },
         "which-module": {
@@ -13613,7 +14932,7 @@
             "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
             "dev": true,
             "requires": {
-                "string-width": "1.0.2"
+                "string-width": "^1.0.2"
             }
         },
         "widest-line": {
@@ -13622,7 +14941,7 @@
             "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
             "dev": true,
             "requires": {
-                "string-width": "1.0.2"
+                "string-width": "^1.0.1"
             }
         },
         "window-size": {
@@ -13637,12 +14956,12 @@
             "integrity": "sha1-gIBQuT1SZh7Z+2wms/DIJnCLCu4=",
             "dev": true,
             "requires": {
-                "async": "1.0.0",
-                "colors": "1.0.3",
-                "cycle": "1.0.3",
-                "eyes": "0.1.8",
-                "isstream": "0.1.2",
-                "stack-trace": "0.0.10"
+                "async": "~1.0.0",
+                "colors": "1.0.x",
+                "cycle": "1.0.x",
+                "eyes": "0.1.x",
+                "isstream": "0.1.x",
+                "stack-trace": "0.0.x"
             },
             "dependencies": {
                 "async": {
@@ -13665,10 +14984,10 @@
             "integrity": "sha1-q1X2leYRjak4WP3XDAU9HF4BrCA=",
             "dev": true,
             "requires": {
-                "array-back": "1.0.4",
-                "feature-detect-es6": "1.3.1",
-                "reduce-flatten": "1.0.1",
-                "typical": "2.6.1"
+                "array-back": "^1.0.3",
+                "feature-detect-es6": "^1.3.1",
+                "reduce-flatten": "^1.0.1",
+                "typical": "^2.6.0"
             }
         },
         "wrap-ansi": {
@@ -13677,8 +14996,8 @@
             "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
             "dev": true,
             "requires": {
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1"
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1"
             }
         },
         "wrappy": {
@@ -13693,9 +15012,9 @@
             "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "imurmurhash": "0.1.4",
-                "slide": "1.1.6"
+                "graceful-fs": "^4.1.11",
+                "imurmurhash": "^0.1.4",
+                "slide": "^1.1.5"
             }
         },
         "ws": {
@@ -13704,8 +15023,8 @@
             "integrity": "sha1-CC3bbGQehdS7RR8D1S8G6r2x8Bg=",
             "dev": true,
             "requires": {
-                "options": "0.0.6",
-                "ultron": "1.0.2"
+                "options": ">=0.0.5",
+                "ultron": "1.0.x"
             }
         },
         "wtf-8": {
@@ -13720,7 +15039,7 @@
             "integrity": "sha1-7byQPMOF/ARSPZZqM1UEtVBNG9I=",
             "dev": true,
             "requires": {
-                "os-homedir": "1.0.2"
+                "os-homedir": "^1.0.0"
             }
         },
         "xml-char-classes": {
@@ -13773,19 +15092,19 @@
             "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
             "dev": true,
             "requires": {
-                "camelcase": "3.0.0",
-                "cliui": "3.2.0",
-                "decamelize": "1.2.0",
-                "get-caller-file": "1.0.2",
-                "os-locale": "1.4.0",
-                "read-pkg-up": "1.0.1",
-                "require-directory": "2.1.1",
-                "require-main-filename": "1.0.1",
-                "set-blocking": "2.0.0",
-                "string-width": "1.0.2",
-                "which-module": "1.0.0",
-                "y18n": "3.2.1",
-                "yargs-parser": "4.2.1"
+                "camelcase": "^3.0.0",
+                "cliui": "^3.2.0",
+                "decamelize": "^1.1.1",
+                "get-caller-file": "^1.0.1",
+                "os-locale": "^1.4.0",
+                "read-pkg-up": "^1.0.1",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^1.0.2",
+                "which-module": "^1.0.0",
+                "y18n": "^3.2.1",
+                "yargs-parser": "^4.2.0"
             },
             "dependencies": {
                 "camelcase": {
@@ -13802,7 +15121,7 @@
             "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
             "dev": true,
             "requires": {
-                "camelcase": "3.0.0"
+                "camelcase": "^3.0.0"
             },
             "dependencies": {
                 "camelcase": {
@@ -13820,8 +15139,8 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "buffer-crc32": "0.2.13",
-                "fd-slicer": "1.0.1"
+                "buffer-crc32": "~0.2.3",
+                "fd-slicer": "~1.0.1"
             }
         },
         "yeast": {
@@ -13836,18 +15155,18 @@
             "integrity": "sha1-zYX6Z9FWBg5EDXgH1+988NLR1nE=",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "debug": "2.2.0",
-                "diff": "2.2.3",
-                "escape-string-regexp": "1.0.5",
-                "globby": "4.1.0",
-                "grouped-queue": "0.3.3",
-                "inquirer": "1.2.3",
-                "lodash": "4.17.4",
-                "log-symbols": "1.0.2",
-                "mem-fs": "1.1.3",
-                "text-table": "0.2.0",
-                "untildify": "2.1.0"
+                "chalk": "^1.0.0",
+                "debug": "^2.0.0",
+                "diff": "^2.1.2",
+                "escape-string-regexp": "^1.0.2",
+                "globby": "^4.0.0",
+                "grouped-queue": "^0.3.0",
+                "inquirer": "^1.0.2",
+                "lodash": "^4.11.1",
+                "log-symbols": "^1.0.1",
+                "mem-fs": "^1.1.0",
+                "text-table": "^0.2.0",
+                "untildify": "^2.0.0"
             },
             "dependencies": {
                 "diff": {
@@ -13862,11 +15181,11 @@
                     "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
                     "dev": true,
                     "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.3.3",
-                        "path-is-absolute": "1.0.1"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "globby": {
@@ -13875,12 +15194,12 @@
                     "integrity": "sha1-CA9UVJ7BuCpsYOYx/ILhIR2+lfg=",
                     "dev": true,
                     "requires": {
-                        "array-union": "1.0.2",
-                        "arrify": "1.0.1",
-                        "glob": "6.0.4",
-                        "object-assign": "4.1.1",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1"
+                        "array-union": "^1.0.1",
+                        "arrify": "^1.0.0",
+                        "glob": "^6.0.1",
+                        "object-assign": "^4.0.1",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "lodash": {
@@ -13897,36 +15216,36 @@
             "integrity": "sha1-QMK09s374F4ZUv3XKTPw2JJdvfU=",
             "dev": true,
             "requires": {
-                "async": "2.6.0",
-                "chalk": "1.1.3",
-                "class-extend": "0.1.2",
-                "cli-table": "0.3.1",
-                "cross-spawn": "5.1.0",
-                "dargs": "5.1.0",
-                "dateformat": "2.2.0",
-                "debug": "2.2.0",
-                "detect-conflict": "1.0.1",
-                "error": "7.0.2",
-                "find-up": "2.1.0",
-                "github-username": "3.0.0",
-                "glob": "7.1.2",
-                "istextorbinary": "2.1.0",
-                "lodash": "4.17.4",
-                "mem-fs-editor": "3.0.2",
-                "minimist": "1.2.0",
-                "mkdirp": "0.5.1",
-                "path-exists": "3.0.0",
-                "path-is-absolute": "1.0.1",
-                "pretty-bytes": "4.0.2",
-                "read-chunk": "2.1.0",
-                "read-pkg-up": "2.0.0",
-                "rimraf": "2.6.2",
-                "run-async": "2.3.0",
-                "shelljs": "0.7.8",
-                "text-table": "0.2.0",
-                "through2": "2.0.3",
-                "user-home": "2.0.0",
-                "yeoman-environment": "1.6.6"
+                "async": "^2.0.0",
+                "chalk": "^1.0.0",
+                "class-extend": "^0.1.0",
+                "cli-table": "^0.3.1",
+                "cross-spawn": "^5.0.1",
+                "dargs": "^5.1.0",
+                "dateformat": "^2.0.0",
+                "debug": "^2.1.0",
+                "detect-conflict": "^1.0.0",
+                "error": "^7.0.2",
+                "find-up": "^2.1.0",
+                "github-username": "^3.0.0",
+                "glob": "^7.0.3",
+                "istextorbinary": "^2.1.0",
+                "lodash": "^4.11.1",
+                "mem-fs-editor": "^3.0.0",
+                "minimist": "^1.2.0",
+                "mkdirp": "^0.5.0",
+                "path-exists": "^3.0.0",
+                "path-is-absolute": "^1.0.0",
+                "pretty-bytes": "^4.0.2",
+                "read-chunk": "^2.0.0",
+                "read-pkg-up": "^2.0.0",
+                "rimraf": "^2.2.0",
+                "run-async": "^2.0.0",
+                "shelljs": "^0.7.0",
+                "text-table": "^0.2.0",
+                "through2": "^2.0.0",
+                "user-home": "^2.0.0",
+                "yeoman-environment": "^1.1.0"
             },
             "dependencies": {
                 "async": {
@@ -13935,7 +15254,7 @@
                     "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
                     "dev": true,
                     "requires": {
-                        "lodash": "4.17.4"
+                        "lodash": "^4.14.0"
                     }
                 },
                 "cross-spawn": {
@@ -13944,9 +15263,9 @@
                     "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
                     "dev": true,
                     "requires": {
-                        "lru-cache": "4.1.1",
-                        "shebang-command": "1.2.0",
-                        "which": "1.3.0"
+                        "lru-cache": "^4.0.1",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
                     }
                 },
                 "find-up": {
@@ -13955,7 +15274,7 @@
                     "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
                     "dev": true,
                     "requires": {
-                        "locate-path": "2.0.0"
+                        "locate-path": "^2.0.0"
                     }
                 },
                 "glob": {
@@ -13964,12 +15283,12 @@
                     "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.3.3",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "load-json-file": {
@@ -13978,10 +15297,10 @@
                     "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "parse-json": "2.2.0",
-                        "pify": "2.3.0",
-                        "strip-bom": "3.0.0"
+                        "graceful-fs": "^4.1.2",
+                        "parse-json": "^2.2.0",
+                        "pify": "^2.0.0",
+                        "strip-bom": "^3.0.0"
                     }
                 },
                 "lodash": {
@@ -13996,8 +15315,8 @@
                     "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
                     "dev": true,
                     "requires": {
-                        "pseudomap": "1.0.2",
-                        "yallist": "2.1.2"
+                        "pseudomap": "^1.0.2",
+                        "yallist": "^2.1.2"
                     }
                 },
                 "mkdirp": {
@@ -14029,7 +15348,7 @@
                     "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
                     "dev": true,
                     "requires": {
-                        "pify": "2.3.0"
+                        "pify": "^2.0.0"
                     }
                 },
                 "read-pkg": {
@@ -14038,9 +15357,9 @@
                     "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
                     "dev": true,
                     "requires": {
-                        "load-json-file": "2.0.0",
-                        "normalize-package-data": "2.4.0",
-                        "path-type": "2.0.0"
+                        "load-json-file": "^2.0.0",
+                        "normalize-package-data": "^2.3.2",
+                        "path-type": "^2.0.0"
                     }
                 },
                 "read-pkg-up": {
@@ -14049,8 +15368,8 @@
                     "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
                     "dev": true,
                     "requires": {
-                        "find-up": "2.1.0",
-                        "read-pkg": "2.0.0"
+                        "find-up": "^2.0.0",
+                        "read-pkg": "^2.0.0"
                     }
                 },
                 "strip-bom": {
@@ -14065,7 +15384,7 @@
                     "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
                     "dev": true,
                     "requires": {
-                        "os-homedir": "1.0.2"
+                        "os-homedir": "^1.0.0"
                     }
                 }
             }
@@ -14076,10 +15395,10 @@
             "integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
             "dev": true,
             "requires": {
-                "archiver-utils": "1.3.0",
-                "compress-commons": "1.2.2",
-                "lodash": "4.17.4",
-                "readable-stream": "2.3.3"
+                "archiver-utils": "^1.3.0",
+                "compress-commons": "^1.2.0",
+                "lodash": "^4.8.0",
+                "readable-stream": "^2.0.0"
             },
             "dependencies": {
                 "lodash": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "px-dropdown",
   "author": "General Electric",
   "description": "A Predix UI Dropdown component",
-  "version": "4.7.8",
+  "version": "4.7.9",
   "extName": null,
   "scripts": {
     "clean": "gulp clean",

--- a/sass/px-dropdown.scss
+++ b/sass/px-dropdown.scss
@@ -63,6 +63,15 @@ $inuit-enable-btn--primary: true;
   --iron-icon-width: calculateRem(16px);
   --iron-icon-height: calculateRem(16px);
   margin-left: $inuit-base-spacing-unit--tiny;
+  /*
+    These margins are for pages that are rendered from "Right-To-Left" or "Left-To-Right"
+    If the writing direction is left-to-right, this value overrides margin-left.
+    If the writing direction is right-to-left, this value overrides margin-right.
+  */
+  -webkit-margin-start: $inuit-base-spacing-unit--tiny;
+  -moz-markin-start: $inuit-base-spacing-unit--tiny;
+  -webkit-margin-end: $inuit-base-spacing-unit--tiny;
+  -moz-markin-end: $inuit-base-spacing-unit--tiny;
 }
 .dropdown{
   font-size: var(--px-dropdown-content-font-size, inherit);


### PR DESCRIPTION
When the browser direction is Right to Left or Left to Right we need to override the margin-right which is present

Issue: When the user of language Hebrew or arabic is viewed the direction of render would be "rtl" and the margins on the icons were making the render on "rtl" wonky"

Fix: To use -webkit-margin-start/ -webkit-margin-end which will , If the writing direction is left-to-right, this value overrides margin-left. If the writing direction is right-to-left, this value overrides margin-right.
Ref jira :https://servicemax.atlassian.net/browse/UI-3074